### PR TITLE
Wait on correct Promise in subscription

### DIFF
--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -208,10 +208,10 @@ export class SubscriptionManager {
             }
 
             // 3. subscribe and keep the subscription id
-            const subsPromise = this.pubsub.subscribe(triggerName, onMessage, channelOptions);
-            subsPromise.then(id => this.subscriptions[externalSubscriptionId].push(id));
-
-            subscriptionPromises.push(subsPromise);
+            subscriptionPromises.push(
+                this.pubsub.subscribe(triggerName, onMessage, channelOptions)
+                    .then(id => this.subscriptions[externalSubscriptionId].push(id))
+            );
         });
 
         // Resolve the promise with external sub id only after all subscriptions completed


### PR DESCRIPTION
I'm not a Promise expert, but the previous code at least read like it was
possible for the Promise returned by subscribe to resolve once all the
this.pubsub.subscribe Promises resolved but before all of the "push onto
this.subscriptions" Promises resolved.  If unsubscribe was called too quickly,
you could in theory end up calling one of those "push" functions after the
`delete this.subscriptions[subId]` line and crashing.

In practice the old code does appear to work but this code more accurately shows
the intentions.

@benjamn this is the code I asked you for advice on, thanks!