### PR TITLE
Return the promise from onMessage

### DIFF
--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -190,7 +190,7 @@ export class SubscriptionManager {
                 } else {
                     contextPromise = Promise.resolve(options.context);
                 }
-                contextPromise.then((context) => {
+                return contextPromise.then((context) => {
                     if (!filter(rootValue, context)) {
                         return;
                     }


### PR DESCRIPTION
This is a super simple change, with the major benefit being that pubsub can `.then` onto the returned promise from the `onMessage` handler to do interesting things like instrument the time it took to perform a subscription.