### PR TITLE
introduce GraphQLExecutorWithSubscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "https://github.com/apollostack/graphql-subscriptions.git"
   },
   "dependencies": {
-    "es6-promise": "^3.2.1"
+    "es6-promise": "^3.2.1",
+    "graphql-server-core": "file://../graphql-server/packages/graphql-server-core",
+    "graphql-server-reactive-core": "file://../graphql-server/packages/graphql-server-reactive-core"
   },
   "peerDependencies": {
     "graphql": "^0.7.0 || ^0.8.0 || ^0.9.0"
@@ -25,6 +27,7 @@
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info"
   },
   "devDependencies": {
+    "@types/graphql": "^0.8.6",
     "@types/mocha": "^2.2.39",
     "@types/node": "^7.0.5",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "dependencies": {
     "es6-promise": "^3.2.1",
-    "graphql-server-core": "file://../graphql-server/packages/graphql-server-core",
-    "graphql-server-reactive-core": "file://../graphql-server/packages/graphql-server-reactive-core"
+    "graphql-server-observable": "file://../graphql-server/packages/graphql-server-observable"
   },
   "peerDependencies": {
     "graphql": "^0.7.0 || ^0.8.0 || ^0.9.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "es6-promise": "^3.2.1",
-    "graphql-server-observable": "file://../graphql-server/packages/graphql-server-observable"
+    "graphql-server-observable": "file:../graphql-server/packages/graphql-server-observable"
   },
   "peerDependencies": {
     "graphql": "^0.7.0 || ^0.8.0 || ^0.9.0"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "url": "https://github.com/apollostack/graphql-subscriptions.git"
   },
   "dependencies": {
-    "es6-promise": "^3.2.1",
-    "graphql-server-observable": "file:../graphql-server/packages/graphql-server-observable"
+    "es6-promise": "^3.2.1"
   },
   "peerDependencies": {
     "graphql": "^0.7.0 || ^0.8.0 || ^0.9.0"

--- a/src/GraphQLExecutorWithSubscriptions.ts
+++ b/src/GraphQLExecutorWithSubscriptions.ts
@@ -94,14 +94,11 @@ export class GraphQLExecutorWithSubscriptions implements RGQLExecutor {
 
     if (this.setupFunctions[subscriptionName]) {
         // TODO: resolve this
-        triggerMap = this.setupFunctions[subscriptionName](undefined as {
-          query: string;
-          operationName: string;
-          callback: Function;
-          variables?: { [key: string]: any };
-          context?: any;
-          formatError?: Function;
-          formatResponse?: Function;
+        triggerMap = this.setupFunctions[subscriptionName]({
+          query: print(document),
+          operationName,
+          variables: variableValues,
+          contextValue,
         }, args, subscriptionName);
     } else {
         // if not provided, the triggerName will be the subscriptionName, The trigger will not have any
@@ -124,10 +121,10 @@ export class GraphQLExecutorWithSubscriptions implements RGQLExecutor {
           // resolver
           const onMessage = (rootValue) => {
               return Promise.resolve().then(() => {
-                  if (typeof context === 'function') {
-                      return (<Function>context)();
+                  if (typeof contextValue === 'function') {
+                      return (<Function>contextValue)();
                   }
-                  return context;
+                  return contextValue;
               }).then((curContext) => {
                   return Promise.all([
                       curContext,

--- a/src/GraphQLExecutorWithSubscriptions.ts
+++ b/src/GraphQLExecutorWithSubscriptions.ts
@@ -1,7 +1,7 @@
 import { execute, OperationDefinitionNode, FieldNode, GraphQLError, validate, DocumentNode, getOperationAST, GraphQLSchema, ExecutionResult, print } from 'graphql';
 import { getArgumentValues } from 'graphql/execution/values';
-import { RGQLExecutor, Observable, IObservable } from 'graphql-server-reactive-core';
-import {  PubSubEngine } from './pubsub';
+import { Observable, IObservable } from 'graphql-server-observable';
+import { PubSubEngine } from './pubsub';
 import {
     subscriptionHasSingleRootField,
 } from './validation';
@@ -44,7 +44,7 @@ export class ValidationError extends Error {
     }
 }
 
-export class GraphQLExecutorWithSubscriptions implements RGQLExecutor {
+export class GraphQLExecutorWithSubscriptions {
   private pubsub: PubSubEngine;
   private setupFunctions: SetupFunctions
 

--- a/src/GraphQLExecutorWithSubscriptions.ts
+++ b/src/GraphQLExecutorWithSubscriptions.ts
@@ -1,0 +1,208 @@
+import { execute, OperationDefinitionNode, FieldNode, GraphQLError, validate, DocumentNode, getOperationAST, GraphQLSchema, ExecutionResult, print } from 'graphql';
+import { getArgumentValues } from 'graphql/execution/values';
+import { RGQLExecutor, Observable, IObservable } from 'graphql-server-reactive-core';
+import {  PubSubEngine } from './pubsub';
+import {
+    subscriptionHasSingleRootField,
+} from './validation';
+
+export interface TriggerConfig {
+    channelOptions?: Object;
+    filter?: Function;
+}
+
+export interface TriggerMap {
+    [triggerName: string]: TriggerConfig;
+}
+
+export interface SetupFunction {
+    // TODO: Resolve the options typing
+    (options: any, args: {[key: string]: any}, subscriptionName: string): TriggerMap;
+    //(options: SubscriptionOptions, args: {[key: string]: any}, subscriptionName: string): TriggerMap;
+}
+
+export interface SetupFunctions {
+    [subscriptionName: string]: SetupFunction;
+}
+
+export interface IObservable<T> {
+  subscribe(observer: {
+    next: (v: any) => void;
+    error: (e: Error) => void;
+    complete: () => void
+  }): () => void;
+}
+
+export class ValidationError extends Error {
+    errors: Array<GraphQLError>;
+    message: string;
+
+    constructor(errors){
+        super();
+        this.errors = errors;
+        this.message = 'Subscription query has validation errors';
+    }
+}
+
+export class GraphQLExecutorWithSubscriptions implements RGQLExecutor {
+  private pubsub: PubSubEngine;
+  private setupFunctions: SetupFunctions
+
+  constructor(options: { pubsub: PubSubEngine, setupFunctions: SetupFunctions }) {
+    this.setupFunctions = options.setupFunctions;
+    this.pubsub = options.pubsub;
+  }
+
+  public handleSubscription(
+    schema: GraphQLSchema,
+    document: DocumentNode,
+    rootValue?: any,
+    contextValue?: any,
+    variableValues?: {[key: string]: any},
+    operationName?: string,
+  ): IObservable<ExecutionResult> {
+
+    // 1. validate the query, operationName and variables
+    const errors = validate(
+      schema,
+      document,
+      [subscriptionHasSingleRootField],
+    );
+
+    // TODO: validate that all variables have been passed (and are of correct type)?
+    if (errors.length){
+      // this error kills the subscription, so we throw it.
+      return Observable.of({ errors: [new ValidationError(errors)] });
+    }
+
+    let args = {};
+
+    // operationName is the name of the only root field in the subscription document
+    let subscriptionName = '';
+    document.definitions.forEach( definition => {
+        if (definition.kind === 'OperationDefinition'){
+            // only one root field is allowed on subscription. No fragments for now.
+            const rootField = (definition as OperationDefinitionNode).selectionSet.selections[0] as FieldNode;
+            subscriptionName = rootField.name.value;
+
+            const fields = schema.getSubscriptionType().getFields();
+            args = getArgumentValues(fields[subscriptionName], rootField, variableValues);
+        }
+    });
+
+    let triggerMap: TriggerMap;
+
+    if (this.setupFunctions[subscriptionName]) {
+        // TODO: resolve this
+        triggerMap = this.setupFunctions[subscriptionName](undefined as {
+          query: string;
+          operationName: string;
+          callback: Function;
+          variables?: { [key: string]: any };
+          context?: any;
+          formatError?: Function;
+          formatResponse?: Function;
+        }, args, subscriptionName);
+    } else {
+        // if not provided, the triggerName will be the subscriptionName, The trigger will not have any
+        // options and rely on defaults that are set later.
+        triggerMap = {[subscriptionName]: {}};
+    }
+
+    return new Observable((observer) => {
+      const subscriptionPromises: Promise<number>[] = Object.keys(triggerMap).map( triggerName => {
+          // Deconstruct the trigger options and set any defaults
+          const {
+              channelOptions = {},
+              filter = () => true, // Let all messages through by default.
+          } = triggerMap[triggerName];
+
+          // 2. generate the handler function
+          //
+          // rootValue is the payload sent by the event emitter / trigger by
+          // convention this is the value returned from the mutation
+          // resolver
+          const onMessage = (rootValue) => {
+              return Promise.resolve().then(() => {
+                  if (typeof context === 'function') {
+                      return (<Function>context)();
+                  }
+                  return context;
+              }).then((curContext) => {
+                  return Promise.all([
+                      curContext,
+                      filter(rootValue, curContext),
+                  ]);
+              }).then(([curContext, doExecute]) => {
+                if (!doExecute) {
+                  return;
+                }
+                execute(
+                    schema,
+                    document,
+                    rootValue,
+                    curContext,
+                    variableValues,
+                    operationName
+                ).then( data => observer.next(data) );
+              }).catch((error) => {
+                  observer.error(error);
+                  observer.complete();
+              });
+          }
+
+          // 3. subscribe and keep the subscription id
+          return this.pubsub.subscribe(triggerName, onMessage, channelOptions);
+      });
+
+      return () => {
+        // Unsubscribe all pubsubs.
+        return Promise.all(subscriptionPromises).then((subIds) => {
+          subIds.forEach((id) => this.pubsub.unsubscribe(id));
+        });
+      };
+    });
+  }
+
+  public executeReactive(
+    schema: GraphQLSchema,
+    document: DocumentNode,
+    rootValue?: any,
+    contextValue?: any,
+    variableValues?: {[key: string]: any},
+    operationName?: string,
+  ): IObservable<ExecutionResult> {
+    const operationAST = getOperationAST(document, operationName);
+    if ( null === operationAST ) {
+      return Observable.of({ errors: [new Error(`could not parse operation on query`)] });
+    }
+
+    if ( operationAST.operation === 'subscription' ) {
+      return this.handleSubscription(schema, document, rootValue, contextValue, variableValues, operationName);
+    } else {
+      return this.handleStatic(schema, document, rootValue, contextValue, variableValues, operationName);
+    }
+  }
+
+  protected handleStatic(
+    schema: GraphQLSchema,
+    document: DocumentNode,
+    rootValue?: any,
+    contextValue?: any,
+    variableValues?: {[key: string]: any},
+    operationName?: string,
+  ): IObservable<ExecutionResult> {
+    return new Observable((observer) => {
+      execute(schema, document, rootValue, contextValue, variableValues, operationName)
+      .then((value) => {
+        observer.next(value);
+        observer.complete();
+      }, (e) => {
+        observer.error(e);
+        observer.complete();
+      });
+
+      return () => {/* noop */};
+    });
+  }
+}

--- a/src/SubscriptionManager.ts
+++ b/src/SubscriptionManager.ts
@@ -1,0 +1,78 @@
+import { GraphQLExecutorWithSubscriptions } from './GraphQLExecutorWithSubscriptions';
+import { GraphQLSchema, validate, specifiedRules, parse} from 'graphql';
+import { SetupFunctions, ValidationError } from './GraphQLExecutorWithSubscriptions';
+import { Subscription } from 'graphql-server-reactive-core';
+import { PubSubEngine } from './pubsub';
+
+export interface SubscriptionOptions {
+    query: string;
+    operationName: string;
+    callback: Function;
+    variables?: { [key: string]: any };
+    context?: any;
+    formatError?: Function;
+    formatResponse?: Function;
+};
+
+// This manages actual GraphQL subscriptions.
+export class SubscriptionManager {
+    private schema: GraphQLSchema;
+    private executor: GraphQLExecutorWithSubscriptions;
+    private subscriptions: { [externalId: number]: Subscription };
+    private maxSubscriptionId: number;
+
+    constructor(options: {  schema: GraphQLSchema,
+                            setupFunctions: SetupFunctions,
+                            pubsub: PubSubEngine }){
+        this.executor = new GraphQLExecutorWithSubscriptions({
+          pubsub: options.pubsub,
+          setupFunctions: options.setupFunctions,
+        });
+        this.schema = options.schema;
+        this.subscriptions = {};
+        this.maxSubscriptionId = 0;
+    }
+
+    public subscribe(options: SubscriptionOptions): Promise<number> {
+        const document = parse(options.query);
+        const errors = validate(
+            this.schema,
+            document,
+            specifiedRules,
+        );
+
+        if (errors.length){
+            // this error kills the subscription, so we throw it.
+            return Promise.reject<number>(new ValidationError(errors));
+        }
+
+        const args = {};
+        const externalSubscriptionId = this.maxSubscriptionId++;
+        const resultObservable = this.executor.executeReactive(
+          this.schema,
+          document,
+          undefined,
+          options.context,
+          options.variables,
+          options.operationName
+        );
+
+        this.subscriptions[externalSubscriptionId] = resultObservable.subscribe({
+          next: (v) => options.callback(undefined, v),
+          error: (e) => options.callback(e, undefined),
+          complete: () => this.unsubscribe(externalSubscriptionId),
+        });
+
+        // Resolve the promise with external sub id only after all subscriptions completed
+        return Promise.resolve<number>(externalSubscriptionId);
+    }
+
+    public unsubscribe(subId: number){
+        if ( ! this.subscriptions.hasOwnProperty(subId) ) {
+          return;
+        }
+
+        this.subscriptions[subId].unsubscribe();
+        delete this.subscriptions[subId];
+    }
+}

--- a/src/SubscriptionManager.ts
+++ b/src/SubscriptionManager.ts
@@ -1,7 +1,7 @@
 import { GraphQLExecutorWithSubscriptions } from './GraphQLExecutorWithSubscriptions';
 import { GraphQLSchema, validate, specifiedRules, parse} from 'graphql';
 import { SetupFunctions, ValidationError } from './GraphQLExecutorWithSubscriptions';
-import { Subscription } from 'graphql-server-reactive-core';
+import { Subscription } from 'graphql-server-observable';
 import { PubSubEngine } from './pubsub';
 
 export interface SubscriptionOptions {

--- a/src/SubscriptionManager.ts
+++ b/src/SubscriptionManager.ts
@@ -1,7 +1,6 @@
 import { GraphQLExecutorWithSubscriptions } from './GraphQLExecutorWithSubscriptions';
 import { GraphQLSchema, validate, specifiedRules, parse} from 'graphql';
 import { SetupFunctions, ValidationError } from './GraphQLExecutorWithSubscriptions';
-import { Subscription } from 'graphql-server-observable';
 import { PubSubEngine } from './pubsub';
 
 export interface SubscriptionOptions {
@@ -18,7 +17,7 @@ export interface SubscriptionOptions {
 export class SubscriptionManager {
     private schema: GraphQLSchema;
     private executor: GraphQLExecutorWithSubscriptions;
-    private subscriptions: { [externalId: number]: Subscription };
+    private subscriptions: { [externalId: number]: { unsubscribe: () => void } };
     private maxSubscriptionId: number;
 
     constructor(options: {  schema: GraphQLSchema,
@@ -58,7 +57,7 @@ export class SubscriptionManager {
         );
 
         this.subscriptions[externalSubscriptionId] = resultObservable.subscribe({
-          next: (v) => options.callback(undefined, v),
+          next: (v) => options.callback(null, v),
           error: (e) => options.callback(e, undefined),
           // XXX: Old subscription manager behavior was not to clean for the user,
           // and error on double clear. do we want to fix it?

--- a/src/SubscriptionManager.ts
+++ b/src/SubscriptionManager.ts
@@ -60,7 +60,10 @@ export class SubscriptionManager {
         this.subscriptions[externalSubscriptionId] = resultObservable.subscribe({
           next: (v) => options.callback(undefined, v),
           error: (e) => options.callback(e, undefined),
-          complete: () => this.unsubscribe(externalSubscriptionId),
+          // XXX: Old subscription manager behavior was not to clean for the user,
+          // and error on double clear. do we want to fix it?
+          // complete: () => this.unsubscribe(externalSubscriptionId),
+          complete: () => {/* noop */},
         });
 
         // Resolve the promise with external sub id only after all subscriptions completed
@@ -68,8 +71,8 @@ export class SubscriptionManager {
     }
 
     public unsubscribe(subId: number){
-        if ( ! this.subscriptions.hasOwnProperty(subId) ) {
-          return;
+        if ( false === this.subscriptions.hasOwnProperty(subId) ) {
+          throw new Error(`${subId} is not a valid subscription id`);
         }
 
         this.subscriptions[subId].unsubscribe();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export { PubSub, SubscriptionManager } from './pubsub';
+export { GraphQLExecutorWithSubscriptions } from './GraphQLExecutorWithSubscriptions';
+export { PubSub, PubSubEngine } from './pubsub';
+export { SubscriptionOptions, SubscriptionManager } from './SubscriptionManager';

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -2,21 +2,6 @@
 // This is basically just event emitters wrapped with a function that filters messages.
 //
 import { EventEmitter } from 'events';
-import {
-    GraphQLSchema,
-    GraphQLError,
-    validate,
-    execute,
-    parse,
-    specifiedRules,
-    OperationDefinition,
-    Field,
-} from 'graphql';
-import { getArgumentValues } from 'graphql/execution/values';
-
-import {
-    subscriptionHasSingleRootField,
-} from './validation';
 
 export interface PubSubEngine {
   publish(triggerName: string, payload: any): boolean;
@@ -42,7 +27,9 @@ export class PubSub implements PubSubEngine {
         return true;
     }
 
-    public subscribe(triggerName: string, onMessage: Function): Promise<number> {
+    public subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number> {
+        // XXX: channelOptions was not defined or used here, yet in the interface.
+
         this.ee.addListener(triggerName, onMessage);
         this.subIdCounter = this.subIdCounter + 1;
         this.subscriptions[this.subIdCounter] = [triggerName, onMessage];
@@ -53,169 +40,5 @@ export class PubSub implements PubSubEngine {
         const [triggerName, onMessage] = this.subscriptions[subId];
         delete this.subscriptions[subId];
         this.ee.removeListener(triggerName, onMessage);
-    }
-}
-
-export class ValidationError extends Error {
-    errors: Array<GraphQLError>;
-    message: string;
-
-    constructor(errors){
-        super();
-        this.errors = errors;
-        this.message = 'Subscription query has validation errors';
-    }
-}
-
-export interface SubscriptionOptions {
-    query: string;
-    operationName: string;
-    callback: Function;
-    variables?: { [key: string]: any };
-    context?: any;
-    formatError?: Function;
-    formatResponse?: Function;
-};
-
-export interface TriggerConfig {
-    channelOptions?: Object;
-    filter?: Function;
-}
-
-export interface TriggerMap {
-    [triggerName: string]: TriggerConfig;
-}
-
-export interface SetupFunction {
-    (options: SubscriptionOptions, args: {[key: string]: any}, subscriptionName: string): TriggerMap;
-}
-
-export interface SetupFunctions {
-    [subscriptionName: string]: SetupFunction;
-}
-
-// This manages actual GraphQL subscriptions.
-export class SubscriptionManager {
-    private pubsub: PubSubEngine;
-    private schema: GraphQLSchema;
-    private setupFunctions: SetupFunctions;
-    private subscriptions: { [externalId: number]: Array<number>};
-    private maxSubscriptionId: number;
-
-    constructor(options: {  schema: GraphQLSchema,
-                            setupFunctions: SetupFunctions,
-                            pubsub: PubSubEngine }){
-        this.pubsub = options.pubsub;
-        this.schema = options.schema;
-        this.setupFunctions = options.setupFunctions || {};
-        this.subscriptions = {};
-        this.maxSubscriptionId = 0;
-    }
-
-    public publish(triggerName: string, payload: any) {
-        this.pubsub.publish(triggerName, payload);
-    }
-
-    public subscribe(options: SubscriptionOptions): Promise<number> {
-
-        // 1. validate the query, operationName and variables
-        const parsedQuery = parse(options.query);
-        const errors = validate(
-            this.schema,
-            parsedQuery,
-            [...specifiedRules, subscriptionHasSingleRootField]
-        );
-
-        // TODO: validate that all variables have been passed (and are of correct type)?
-        if (errors.length){
-            // this error kills the subscription, so we throw it.
-            return Promise.reject<number>(new ValidationError(errors));
-        }
-
-        let args = {};
-
-        // operationName is the name of the only root field in the subscription document
-        let subscriptionName = '';
-        parsedQuery.definitions.forEach( definition => {
-            if (definition.kind === 'OperationDefinition'){
-                // only one root field is allowed on subscription. No fragments for now.
-                const rootField = (definition as OperationDefinition).selectionSet.selections[0] as Field;
-                subscriptionName = rootField.name.value;
-
-                const fields = this.schema.getSubscriptionType().getFields();
-                args = getArgumentValues(fields[subscriptionName], rootField, options.variables);
-            }
-        });
-
-        let triggerMap: TriggerMap;
-
-        if (this.setupFunctions[subscriptionName]) {
-            triggerMap = this.setupFunctions[subscriptionName](options, args, subscriptionName);
-        } else {
-            // if not provided, the triggerName will be the subscriptionName, The trigger will not have any
-            // options and rely on defaults that are set later.
-            triggerMap = {[subscriptionName]: {}};
-        }
-
-        const externalSubscriptionId = this.maxSubscriptionId++;
-        this.subscriptions[externalSubscriptionId] = [];
-        const subscriptionPromises = [];
-        Object.keys(triggerMap).forEach( triggerName => {
-            // Deconstruct the trigger options and set any defaults
-            const {
-                channelOptions = {},
-                filter = () => true, // Let all messages through by default.
-            } = triggerMap[triggerName];
-
-            // 2. generate the handler function
-            //
-            // rootValue is the payload sent by the event emitter / trigger by
-            // convention this is the value returned from the mutation
-            // resolver
-            const onMessage = (rootValue) => {
-                return Promise.resolve().then(() => {
-                    if (typeof options.context === 'function') {
-                        return options.context();
-                    }
-                    return options.context;
-                }).then((context) => {
-                    return Promise.all([
-                        context,
-                        filter(rootValue, context),
-                    ]);
-                }).then(([context, doExecute]) => {
-                  if (!doExecute) {
-                    return;
-                  }
-                  execute(
-                      this.schema,
-                      parsedQuery,
-                      rootValue,
-                      context,
-                      options.variables,
-                      options.operationName
-                  ).then( data => options.callback(null, data) );
-                }).catch((error) => {
-                    options.callback(error);
-                });
-            }
-
-            // 3. subscribe and keep the subscription id
-            subscriptionPromises.push(
-                this.pubsub.subscribe(triggerName, onMessage, channelOptions)
-                    .then(id => this.subscriptions[externalSubscriptionId].push(id))
-            );
-        });
-
-        // Resolve the promise with external sub id only after all subscriptions completed
-        return Promise.all(subscriptionPromises).then(() => externalSubscriptionId);
-    }
-
-    public unsubscribe(subId){
-        // pass the subId right through to pubsub. Do nothing else.
-        this.subscriptions[subId].forEach( internalId => {
-            this.pubsub.unsubscribe(internalId);
-        });
-        delete this.subscriptions[subId];
     }
 }

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -21,7 +21,7 @@ export class PubSub implements PubSubEngine {
     }
 
     public publish(triggerName: string, payload: any): boolean {
-        this.ee.emit(triggerName, payload);
+        process.nextTick(() => this.ee.emit(triggerName, payload));
         // Not using the value returned from emit method because it gives
         // irrelevant false when there are no listeners.
         return true;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -436,7 +436,7 @@ describe('SubscriptionManager', function() {
     const callback = function(error, payload) {
       subManager.unsubscribe(subscriptionId);
       try {
-        expect(error).to.be.undefined;
+        expect(error).to.be.null;
         expect(payload.data.testContext).to.eq('trigger');
       } catch (e) {
         return done(e);
@@ -514,7 +514,9 @@ describe('SubscriptionManager', function() {
     const query = `subscription TestArguments {
       testArguments(testArgument: 10)
     }`;
+    let subscriptionId = undefined;
     const callback = function(error, payload) {
+      subManager.unsubscribe(subscriptionId);
       try {
         expect(error).to.be.null;
         expect(capturedArguments).to.eql({ testArgument: 10 });
@@ -530,8 +532,8 @@ describe('SubscriptionManager', function() {
       variables: {},
       callback,
     }).then(subId => {
+      subscriptionId = subId;
       pubsub.publish('Trigger1', 'ignored');
-      subManager.unsubscribe(subId);
     });
   });
 
@@ -539,7 +541,9 @@ describe('SubscriptionManager', function() {
     const query = `subscription TestArguments {
       testArguments
     }`;
+    let subscriptionId = undefined;
     const callback = function(error, payload) {
+      subManager.unsubscribe(subscriptionId);
       try {
         expect(error).to.be.null;
         expect(capturedArguments).to.eql({ testArgument: 1234 });
@@ -555,8 +559,8 @@ describe('SubscriptionManager', function() {
       variables: {},
       callback,
     }).then(subId => {
+      subscriptionId = subId;
       pubsub.publish('Trigger1', 'ignored');
-      subManager.unsubscribe(subId);
     });
   });
 });

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -13,10 +13,8 @@ import {
   GraphQLBoolean,
 } from 'graphql';
 
-import {
-    PubSub,
-    SubscriptionManager,
-} from '../pubsub';
+import { PubSub } from '../pubsub';
+import { SubscriptionManager } from '../SubscriptionManager';
 
 import { subscriptionHasSingleRootField } from '../validation';
 
@@ -31,7 +29,7 @@ describe('PubSub', function() {
     ps.subscribe('a', payload => {
       expect(payload).to.equals('test');
       done();
-    }).then(() => {
+    }, undefined).then(() => {
       const succeed = ps.publish('a', 'test');
       expect(succeed).to.be.true;
     });
@@ -41,7 +39,7 @@ describe('PubSub', function() {
     const ps = new PubSub();
     ps.subscribe('a', payload => {
       assert(false);
-    }).then((subId) => {
+    }, undefined).then((subId) => {
       ps.unsubscribe(subId);
       const succeed = ps.publish('a', 'test');
       expect(succeed).to.be.true; // True because publish success is not
@@ -122,7 +120,6 @@ const schema = new GraphQLSchema({
 
 describe('SubscriptionManager', function() {
   let capturedArguments: Object;
-
   const pubsub = new PubSub();
 
   const subManager = new SubscriptionManager({
@@ -232,7 +229,7 @@ describe('SubscriptionManager', function() {
     };
 
     subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
-      subManager.publish('testSubscription', 'good');
+      pubsub.publish('testSubscription', 'good');
       subManager.unsubscribe(subId);
     });
   });
@@ -260,8 +257,8 @@ describe('SubscriptionManager', function() {
       variables: { filterBoolean: true},
       callback,
     }).then(subId => {
-      subManager.publish('Filter1', {filterBoolean: false });
-      subManager.publish('Filter1', {filterBoolean: true });
+      pubsub.publish('Filter1', {filterBoolean: false });
+      pubsub.publish('Filter1', {filterBoolean: true });
       subManager.unsubscribe(subId);
     });
   });
@@ -289,8 +286,8 @@ describe('SubscriptionManager', function() {
       variables: { filterBoolean: true},
       callback,
     }).then(subId => {
-      subManager.publish('Filter2', {filterBoolean: false });
-      subManager.publish('Filter2', {filterBoolean: true });
+      pubsub.publish('Filter2', {filterBoolean: false });
+      pubsub.publish('Filter2', {filterBoolean: true });
       subManager.unsubscribe(subId);
     });
   });
@@ -321,9 +318,9 @@ describe('SubscriptionManager', function() {
       variables: { filterBoolean: true, uga: 'UGA'},
       callback,
     }).then(subId => {
-      subManager.publish('NotATrigger', {filterBoolean: false});
-      subManager.publish('Trigger1', {filterBoolean: true });
-      subManager.publish('Trigger2', {filterBoolean: true });
+      pubsub.publish('NotATrigger', {filterBoolean: false});
+      pubsub.publish('Trigger1', {filterBoolean: true });
+      pubsub.publish('Trigger2', {filterBoolean: true });
       subManager.unsubscribe(subId);
     });
   });
@@ -366,7 +363,7 @@ describe('SubscriptionManager', function() {
     };
     subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
       subManager.unsubscribe(subId);
-      subManager.publish('testSubscription', 'bad');
+      pubsub.publish('testSubscription', 'bad');
       setTimeout(done, 30);
     });
   });
@@ -403,7 +400,7 @@ describe('SubscriptionManager', function() {
     };
 
     subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
-      subManager.publish('testSubscription', 'good');
+      pubsub.publish('testSubscription', 'good');
       subManager.unsubscribe(subId);
     });
   });
@@ -425,7 +422,7 @@ describe('SubscriptionManager', function() {
       variables: {},
       callback,
     }).then(subId => {
-      subManager.publish('contextTrigger', 'ignored');
+      pubsub.publish('contextTrigger', 'ignored');
       subManager.unsubscribe(subId);
     });
   });
@@ -452,7 +449,7 @@ describe('SubscriptionManager', function() {
       variables: {},
       callback,
     }).then(subId => {
-      subManager.publish('contextTrigger', 'ignored');
+      pubsub.publish('contextTrigger', 'ignored');
       subManager.unsubscribe(subId);
     });
   });
@@ -477,7 +474,7 @@ describe('SubscriptionManager', function() {
       variables: {},
       callback,
     }).then(subId => {
-      subManager.publish('Trigger1', 'ignored');
+      pubsub.publish('Trigger1', 'ignored');
       subManager.unsubscribe(subId);
     });
   });
@@ -502,11 +499,12 @@ describe('SubscriptionManager', function() {
       variables: {},
       callback,
     }).then(subId => {
-      subManager.publish('Trigger1', 'ignored');
+      pubsub.publish('Trigger1', 'ignored');
       subManager.unsubscribe(subId);
     });
   });
 });
+
 // ---------------------------------------------
 // validation tests ....
 
@@ -556,7 +554,6 @@ describe('SubscriptionValidationRule', function() {
     const errors = validate(validationSchema, parse(sub), [subscriptionHasSingleRootField]);
     expect(errors.length).to.equals(0);
   });
-
 
   it('should not allow two fields in the subscription', function() {
     const sub = `subscription S3{

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -242,7 +242,7 @@ describe('SubscriptionManager', function() {
     subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
       subscriptionId = subId;
       pubsub.publish('testSubscription', 'good');
-    });
+    }, done);
   });
 
   it('can use filter functions properly', function(done) {
@@ -273,7 +273,7 @@ describe('SubscriptionManager', function() {
       subscriptionId = subId;
       pubsub.publish('Filter1', {filterBoolean: false });
       pubsub.publish('Filter1', {filterBoolean: true });
-    });
+    }, done);
   });
 
   it('can use a filter function that returns a promise', function(done) {
@@ -305,7 +305,7 @@ describe('SubscriptionManager', function() {
       subscriptionId = subId;
       pubsub.publish('Filter2', {filterBoolean: false });
       pubsub.publish('Filter2', {filterBoolean: true });
-    });
+    }, done);
   });
 
   it('can subscribe to more than one trigger', function(done) {
@@ -340,7 +340,7 @@ describe('SubscriptionManager', function() {
       pubsub.publish('NotATrigger', {filterBoolean: false});
       pubsub.publish('Trigger1', {filterBoolean: true });
       pubsub.publish('Trigger2', {filterBoolean: true });
-    });
+    }, done);
   });
 
   it('can subscribe to a trigger and pass options to PubSub using "channelOptions"', function(done) {
@@ -387,7 +387,7 @@ describe('SubscriptionManager', function() {
     subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
       subscriptionId = subId;
       pubsub.publish('testSubscription', 'bad');
-    });
+    }, done);
   });
 
   it('throws an error when trying to unsubscribe from unknown id', function () {
@@ -426,7 +426,7 @@ describe('SubscriptionManager', function() {
     subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
       subscriptionId = subId;
       pubsub.publish('testSubscription', 'good');
-    });
+    }, done);
   });
 
   it('calls context if it is a function', function(done) {
@@ -454,7 +454,7 @@ describe('SubscriptionManager', function() {
     }).then(subId => {
       subscriptionId = subId;
       pubsub.publish('contextTrigger', 'ignored');
-    });
+    }, done);
   });
 
   it('call the error callback if a context functions throws an error', function(done) {
@@ -483,7 +483,30 @@ describe('SubscriptionManager', function() {
     }).then(subId => {
       subscriptionId = subId;
       pubsub.publish('contextTrigger', 'ignored');
-    });
+    }, done);
+  });
+
+  it('runs the correct operation', function(done) {
+    const query = 'subscription S { testSubscription }\n\nquery Q { testString }';
+    let subscriptionId = undefined;
+    const callback = function(err, payload){
+      subManager.unsubscribe(subscriptionId);
+      try {
+        if (err) {
+          throw err;
+        }
+
+        expect(payload.data.testSubscription).to.equals('good');
+      } catch (e) {
+        return done(e);
+      }
+      return done();
+    };
+
+    subManager.subscribe({ query, operationName: 'S', callback }).then(subId => {
+      subscriptionId = subId;
+      pubsub.publish('testSubscription', 'good');
+    }, done);
   });
 
   it('passes arguments to setupFunction', function(done) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,12 +1,11 @@
 import {
   ValidationContext,
-  Selection,
+  SelectionNode,
   GraphQLError,
 } from 'graphql';
 
 // XXX I don't know how else to do this. Can't seem to import from GraphQL.
 const FIELD = 'Field';
-
 
 export function tooManySubscriptionFieldsError(subscriptionName: string): string {
   return `Subscription "${subscriptionName}" must have only one field.`;
@@ -21,7 +20,7 @@ export function subscriptionHasSingleRootField(context: ValidationContext): any 
     OperationDefinition(node) {
       const operationName = node.name ? node.name.value : '';
       let numFields = 0;
-      node.selectionSet.selections.forEach( (selection: Selection) => {
+      node.selectionSet.selections.forEach( (selection: SelectionNode) => {
         if (selection.kind === FIELD) {
           numFields++;
         } else {


### PR DESCRIPTION
Hey,

I've refactored `graphql-subscriptions` so the execution logic will be isolated then the SubscriptionManager.
With this executor we will support subscriptions for the new `graphql-server-ws` package.

**This PR also adds support for query/mutation.**

TODO:
 - [x] Update README.md add example.