### PR TITLE
Properly propagate return() and throw() through withFilter

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "posttest": "npm run lint",
     "lint": "tslint --type-check --project ./tsconfig.json ./src/**/*.ts",
     "watch": "tsc -w",
-    "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js",
+    "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js ",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info"
   },

--- a/src/test/asyncIteratorSubscription.ts
+++ b/src/test/asyncIteratorSubscription.ts
@@ -1,0 +1,107 @@
+// chai style expect().to.be.true  violates no-unused-expression
+/* tslint:disable:no-unused-expression */
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinonChai from 'sinon-chai';
+
+import { isAsyncIterable } from 'iterall';
+import { PubSub } from '../pubsub';
+import { withFilter } from '../with-filter';
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+const expect = chai.expect;
+
+import {
+  parse,
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+import { subscribe } from 'graphql/subscription';
+
+const FIRST_EVENT = 'FIRST_EVENT';
+
+function prepare() {
+  const pubsub = new PubSub();
+
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        testString: {
+          type: GraphQLString,
+          resolve: function(_, args) {
+            return 'works';
+          },
+        },
+      },
+    }),
+    subscription: new GraphQLObjectType({
+      name: 'Subscription',
+      fields: {
+        testSubscription: {
+          type: GraphQLString,
+          subscribe: withFilter(
+            () => pubsub.asyncIterator(FIRST_EVENT),
+            () => true,
+          ),
+          resolve: root => {
+            return 'FIRST_EVENT';
+          },
+        },
+      },
+    }),
+  });
+
+  return { pubsub, schema };
+}
+
+describe('GraphQL-JS asyncIterator', () => {
+  it('should allow subscriptions', () => {
+    const query = parse(`
+      subscription S1 {
+        testSubscription
+      }
+    `);
+
+    const { schema, pubsub } = prepare();
+
+    const results = subscribe(schema, query);
+    const payload1 = results.next();
+
+    expect(isAsyncIterable(results)).to.be.true;
+
+    const r = payload1.then(res => {
+      expect(res.value.data.testSubscription).to.equal('FIRST_EVENT');
+    });
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return r;
+  });
+
+  it('should clear event handlers', () => {
+    const query = parse(`
+      subscription S1 {
+        testSubscription
+      }
+    `);
+
+    const { schema, pubsub } = prepare();
+
+    const results = subscribe(schema, query);
+    const end = results.return();
+
+    const r = end.then(res => {
+      // TypeScript trick to access private properties
+      const eventHandlers = (<any>pubsub).ee._events;
+      expect(eventHandlers[FIRST_EVENT]).to.be.undefined;
+    });
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return r;
+  });
+});

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -29,10 +29,10 @@ export const withFilter = (asyncIteratorFn: () => AsyncIterator<any>, filterFn: 
         return getNextPromise();
       },
       return() {
-        return Promise.resolve({ value: undefined, done: true });
+        return asyncIterator.return();
       },
       throw(error) {
-        return Promise.reject(error);
+        return asyncIterator.throw(error);
       },
       [$$asyncIterator]() {
         return this;


### PR DESCRIPTION
This PR fixes #73 (and possibly https://github.com/apollographql/subscriptions-transport-ws/issues/154)

### Summary
`withFilter` is a wrapper around an asyncIterator, providing filtering of subsequent values.

When a graphql subscription is ended, graphql-js will either call `return()` or `throw()` on all related asyncIterators.

Current implementation of `withFilter` would not propagate those calls to the wrapped asyncIterator resulting in event handlers not being properly unregistered and nasty memory leak :skull:.

This PR fixes this behaviour by making `withFilter` call the relevant method on the underlying asyncIterator.

### Implementation
Bugfix implementation is trivial, `withFilter` now correctly acts as a proxy to the original asyncIterator.

I'm a bit more concerned about the test implementation. I chose to create a new test file, as `src/test/tests.ts` felt large enough already and is difficult to read.