### PR TITLE
Add note about production usage of the default PubSub implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Now, GraphQL engine knows that `somethingChanged` is a subscription, and every t
 pubsub.publish(SOMETHING_CHANGED_TOPIC, { somethingChanged: { id: "123" }});
 ```
 
+> Note that the default PubSub implementation is intended for demo purposes. It only works if you have a single instance of your server and doesn't scale beyond a couple of connections.
+> For production usage you'll want to use one of the [PubSub implementations](#pubsub-implementations) backed by an external store. (e.g. Redis)
+
 ### Filters
 
 When publishing data to subscribers, we need to make sure that each subscribers get only the data it need.


### PR DESCRIPTION
Based on [this StackOverflow answer](https://stackoverflow.com/a/43790449/2115623) by @helfer I've added a pretty important note to the README that the default `PubSub` implementation should not be used in production.

I did not realise this and have been running it in production across multiple instances for months now. We've had memory leak warnings and all that, but couldn't pinpoint the source until I randomly stumbled upon that StackOverflow answer. In hindsight it's obvious, but when you're in the middle of a huge codebase with complex real-time requirements it's not obvious at all.