### PR TITLE
AsyncIterator with backlog + pubsub decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .vscode
 coverage

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "scripts": {
     "preinstall": "npm run compile",
-    "prepare": "npm run compile",
     "compile": "tsc",
     "pretest": "npm run compile",
     "test": "npm run testonly --",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "graphql": "^0.10.5 || ^0.11.3"
   },
   "scripts": {
+    "preinstall": "npm run compile",
+    "prepare": "npm run compile",
     "compile": "tsc",
     "pretest": "npm run compile",
     "test": "npm run testonly --",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "graphql": "^0.10.5 || ^0.11.3"
   },
   "scripts": {
-    "preinstall": "npm run compile",
     "compile": "tsc",
     "pretest": "npm run compile",
     "test": "npm run testonly --",

--- a/src/event-emitter-to-async-iterator.ts
+++ b/src/event-emitter-to-async-iterator.ts
@@ -26,6 +26,12 @@ export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
     });
   };
 
+  const removeEventListeners = () => {
+      for (const eventName of eventsArray) {
+          eventEmitter.removeListener(eventName, pushValue);
+      }
+  };
+
   const emptyQueue = () => {
     if (listening) {
       listening = false;
@@ -39,12 +45,6 @@ export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
   const addEventListeners = () => {
     for (const eventName of eventsArray) {
       eventEmitter.addListener(eventName, pushValue);
-    }
-  };
-
-  const removeEventListeners = () => {
-    for (const eventName of eventsArray) {
-      eventEmitter.removeListener(eventName, pushValue);
     }
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
 export { PubSubEngine } from './pubsub-engine';
 export { PubSub } from './pubsub';
 export { withFilter, ResolverFn, FilterFn } from './with-filter';
+export { createPersistentPubSub } from './persistent-pubsub';
+export {
+    persistenceAsyncIterator,
+    EventItem,
+    PersistenceClient,
+    PersistenceAsyncOptions,
+    SequenceFieldType,
+} from './with-persistance';

--- a/src/persistent-pubsub.ts
+++ b/src/persistent-pubsub.ts
@@ -1,0 +1,32 @@
+import {
+    PubSubEngine,
+    PersistenceClient,
+    PersistenceAsyncOptions,
+    persistenceAsyncIterator,
+} from './index';
+
+export const createPersistentPubSub = (
+    store: PersistenceClient,
+    pubSubEngine: PubSubEngine,
+) => {
+    return {
+        publish(triggerName: string, payload: any, collection: string): boolean {
+            store.save(collection, payload);
+            return pubSubEngine.publish(triggerName, payload);
+        },
+        subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number> {
+            return pubSubEngine.subscribe(triggerName, onMessage, options);
+        },
+        unsubscribe(subId: number) {
+            return pubSubEngine.unsubscribe(subId);
+        },
+        asyncIterator<T>(triggers: string | string[],
+                      options: PersistenceAsyncOptions): AsyncIterator<T> {
+            return persistenceAsyncIterator(
+                store,
+                options,
+                pubSubEngine.asyncIterator(triggers),
+            );
+        },
+    };
+};

--- a/src/persistent-pubsub.ts
+++ b/src/persistent-pubsub.ts
@@ -16,10 +16,15 @@ export const createPersistentPubSub = (
         asyncIterator: <T>(triggers: string | string[]): AsyncIterator<T> =>
             pubSubEngine.asyncIterator(triggers),
 
-        publishWithPersistence(triggerName: string, payload: any, collection: string): boolean {
-            store.save(collection, payload);
-            return pubSubEngine.publish(triggerName, payload);
-        },
+        async publishWithPersistence(triggerName: string, payload: any, collection: string):
+            Promise<{ published: boolean, data: any }> {
+                const data = await store.save(collection, payload);
+                return {
+                    data,
+                    published: pubSubEngine.publish(triggerName, {...payload, ...data}),
+                };
+            },
+
         subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number> {
             return pubSubEngine.subscribe(triggerName, onMessage, options);
         },

--- a/src/persistent-pubsub.ts
+++ b/src/persistent-pubsub.ts
@@ -10,7 +10,13 @@ export const createPersistentPubSub = (
     pubSubEngine: PubSubEngine,
 ) => {
     return {
-        publish(triggerName: string, payload: any, collection: string): boolean {
+        publish: (triggerName: string, payload: any) =>
+            pubSubEngine.publish(triggerName, payload),
+
+        asyncIterator: <T>(triggers: string | string[]): AsyncIterator<T> =>
+            pubSubEngine.asyncIterator(triggers),
+
+        publishWithPersistence(triggerName: string, payload: any, collection: string): boolean {
             store.save(collection, payload);
             return pubSubEngine.publish(triggerName, payload);
         },
@@ -20,7 +26,7 @@ export const createPersistentPubSub = (
         unsubscribe(subId: number) {
             return pubSubEngine.unsubscribe(subId);
         },
-        asyncIterator<T>(triggers: string | string[],
+        asyncIteratorWithPersistence<T>(triggers: string | string[],
                       options: PersistenceAsyncOptions): AsyncIterator<T> {
             return persistenceAsyncIterator(
                 store,

--- a/src/with-persistance.ts
+++ b/src/with-persistance.ts
@@ -4,7 +4,6 @@ export type SequenceFieldType = string;
 
 export interface EventItem {
     seq: SequenceFieldType;
-    payload: any;
 }
 
 export interface FetchNextParams {
@@ -36,22 +35,22 @@ export const persistenceAsyncIterator = <T>(
     let data: Array<EventItem> = [];
     let cursor = options.lastSequence;
 
-    const extractItem = (): Promise<IteratorResult<T>> => new Promise((resolve) => {
+    const extractItem = (): Promise<IteratorResult<EventItem>> => new Promise((resolve) => {
             const item = data.shift();
             cursor = item.seq;
-            // console.log('resolve item', `cursor: ${cursor}`);
+            console.log('resolve item', `cursor: ${cursor}`);
 
             if (options.publishDelay) {
                 setTimeout(() => {
                     resolve({
                         done: false,
-                        value: item.payload,
+                        value: item,
                     });
                 }, options.publishDelay);
             } else {
                 resolve({
                     done: false,
-                    value: item.payload,
+                    value: item,
                 });
             }
         });

--- a/src/with-persistance.ts
+++ b/src/with-persistance.ts
@@ -1,0 +1,75 @@
+import { $$asyncIterator } from 'iterall';
+
+export type SequenceFieldType = string;
+
+export interface EventItem {
+    seq: SequenceFieldType;
+    payload: any;
+}
+
+export interface PersistenceClient {
+    fetchNext: (collection: string, fromSeq: SequenceFieldType, batchSize: number) => Promise<[EventItem]>;
+    save: (collection: string, item: Object) => Promise<any>;
+}
+
+export interface PersistenceAsyncOptions {
+    lastSequence: SequenceFieldType;
+    collection: string;
+    batchSize: number;
+}
+
+export const persistenceAsyncIterator = <T>(
+    store: PersistenceClient,
+    options: PersistenceAsyncOptions,
+    afterAsyncIterator: AsyncIterator<any>,
+): AsyncIterator<T> =>  {
+    const asyncIterator = afterAsyncIterator;
+
+    let hasPersistence = true;
+    let data: Array<EventItem> = [];
+    let cursor = options.lastSequence;
+
+    const extractItem = (resolve) => {
+        const item = data.shift();
+        cursor = item.seq;
+        // console.log('resolve item', `cursor: ${cursor}`, item.payload);
+        resolve({
+            done: false,
+            value: item.payload,
+        });
+    };
+    const fetchData = (resolve) => {
+        store.fetchNext(options.collection, cursor, options.batchSize)
+            .then((result) => {
+                data = result;
+                if (data.length === 0) {
+                    // console.log('NO DATA MORE');
+                    hasPersistence = false;
+                    resolve(asyncIterator.next());
+                } else {
+                    extractItem(resolve);
+                }
+            });
+    };
+
+    return {
+        next() {
+            return new Promise((resolve) => {
+                if (hasPersistence) {
+                    data.length === 0 ? fetchData(resolve) : extractItem(resolve);
+                } else {
+                    resolve(asyncIterator.next());
+                }
+            });
+        },
+        return() {
+            return asyncIterator.return();
+        },
+        throw(error) {
+            return asyncIterator.throw(error);
+        },
+        [$$asyncIterator]() {
+            return this;
+        },
+    };
+};


### PR DESCRIPTION
Support for a backlog mechanism in a asynciterator. 
Can be used to create backlog of publish events. This is especially useful for chat applications such as whatsapp and any other application that are dealing with bad connection.

Usage:
First implement the PersistenceClient interface for your data storage, my implementation of mongodb:

```
{
    fetchNext: (params) => new Promise((resolve) => {

      const {
        collection,
        fromSeq,
        batchSize,
        queryFilter,
      } = params;


      const resolveResult = (err, result) => {
        resolve(result.map(item => ({
          seq: item.timestamp,
          payload: item.payload,
        })));
      };

      // console.log('fetchNext', collection, fromSeq, batchSize);

      const query = {};

      if (fromSeq) {
        query.timestamp = { $gt: fromSeq };
      }

      const finalQuery = Object.assign(query, queryFilter);

      DB.collection(collection).find(finalQuery)
      .sort({ timestamp: 1 })
      .limit(batchSize)
      .toArray(resolveResult);
    }),
    save: (collection, item) => {
      DB.collection(collection).insert({
        timestamp: (new Date()).toISOString(),
        payload: item,
      });
    },
  }
```

Secondly, decorate your pubsub system

```
const pubsubOnline = new MQTTPubSub({
  client,
});

const pubsub = createPersistentPubSub(
  persistenceClient,
  pubsubOnline,
);
```

Publish events with the decorator:

```
pubsub.publishWithPersistence(MESSAGE_MUTATION,
            {
              [MESSAGE_MUTATION]: {
                type: CREATED,
                message: newMessage,
              },
              userIds: channel.participants,
            }, 'persistence');
```

Return the asyncIteratorWithPersistence from the decorator in subscribe:

```
subscribe: withFilter(
        () => pubsub.asyncIteratorWithPersistence(MESSAGE_MUTATION, {
          batchSize: 100,
          collection: 'persistence',
          lastSequence: undefined, // this is the cursor, undefined starts from first element
        }),
          (payload, args, { permission }) =>
            Boolean(payload.userIds && payload.userIds.indexOf(permission.userId) >= 0),
      ),
```

You can pass the lastSequence (cursor) parameter in the socketConnection or as args in the subscription and don't forget to update on every new call.

