### PR TITLE
Document getting payload value in sub resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ export const resolvers = {
     somethingChanged: {
       resolve: (payload, args, context, info) => {
         // Manipulate and return the new value
-
-        return payload;
+        return payload.somethingChanged;
       },
       subscribe: () => pubsub.asyncIterator(SOMETHING_UPDATED),
     },


### PR DESCRIPTION
This should help prevent the confusion described in https://github.com/apollographql/graphql-subscriptions/issues/113 and https://github.com/apollographql/graphql-subscriptions/issues/130

People copy/pasting the example would previously break their working subscription.

I must say it's not very DRY to setup a subscription like this...