### PR TITLE
Add note about callback listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,37 @@ export const resolvers = {
 }
 ````
 
+### Usage with callback listeners
+
+Your database might have callback-based listeners for changes, for example something like this:
+
+```JS
+const listenToNewMessages = (callback) => {
+  return db.table('messages').listen(newMessage => callback(newMessage));
+}
+
+// Kick off the listener
+listenToNewMessages(message => {
+  console.log(message);
+})
+```
+
+The `callback` function would be called every time a new message is saved in the database. Unfortunately, that doesn't play very well with async iterators out of the box because callbacks are push-based, where async iterators are pull-based.
+
+We recommend using the [`callback-to-async-iterator`](https://github.com/withspectrum/callback-to-async-iterator) module to convert your callback-based listener into an async iterator:
+
+```js
+import asyncify from 'callback-to-async-iterator';
+
+export const resolvers = {
+  Subscription: {
+    somethingChanged: {
+      subscribe: () => asyncify(listenToChanges),
+    },
+  },
+}
+````
+
 ### Custom `AsyncIterator` Wrappers
 
 The value you should return from your `subscribe` resolver must be an `AsyncIterator`.


### PR DESCRIPTION
I just published [`callback-to-async-iterator`](https://github.com/withspectrum/callback-to-async-iterator) based on the Event Emitter to Async Iterator module used in graphql-js. Having struggled with this a fair bit, I think a lot of people would appreciate the note on how to work with async iterators!

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->