### PR TITLE
create separate pubsub.asyncIterable method and deprecate pubsub.asyncIterator

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "posttest": "npm run lint",
     "lint": "tslint --type-check --project ./tsconfig.json ./src/**/*.ts",
     "watch": "tsc -w",
-    "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js ",
+    "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js ./dist/test/asyncIterableSubscription.js",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
     "prepublishOnly": "npm run clean && npm run compile"

--- a/src/event-emitter-to-async-iterable.ts
+++ b/src/event-emitter-to-async-iterable.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 import { eventEmitterAsyncIterator } from './event-emitter-to-async-iterator';
 
 export function eventEmitterAsyncIterable<T>(eventEmitter: EventEmitter,
-                                             eventsNames: string | string[]): AsyncIterator<T> {
+                                             eventsNames: string | string[]): AsyncIterable<T> {
   return {
     [$$asyncIterator]() {
       return eventEmitterAsyncIterator(eventEmitter, eventsNames);

--- a/src/event-emitter-to-async-iterable.ts
+++ b/src/event-emitter-to-async-iterable.ts
@@ -1,13 +1,13 @@
 import { $$asyncIterator } from 'iterall';
 import { EventEmitter } from 'events';
 
-import { eventEmitterToAsyncIterator } from './event-emitter-to-async-iterator';
+import { eventEmitterAsyncIterator } from './event-emitter-to-async-iterator';
 
 export function eventEmitterAsyncIterable<T>(eventEmitter: EventEmitter,
                                              eventsNames: string | string[]): AsyncIterator<T> {
   return {
     [$$asyncIterator]() {
-      return eventEmitterToAsyncIterator(eventEmitter, eventsNames);
+      return eventEmitterAsyncIterator(eventEmitter, eventsNames);
     },
   };
 }

--- a/src/event-emitter-to-async-iterable.ts
+++ b/src/event-emitter-to-async-iterable.ts
@@ -1,0 +1,13 @@
+import { $$asyncIterator } from 'iterall';
+import { EventEmitter } from 'events';
+
+import { eventEmitterToAsyncIterator } from './event-emitter-to-async-iterator';
+
+export function eventEmitterAsyncIterable<T>(eventEmitter: EventEmitter,
+                                             eventsNames: string | string[]): AsyncIterator<T> {
+  return {
+    [$$asyncIterator]() {
+      return eventEmitterToAsyncIterator(eventEmitter, eventsNames);
+    },
+  };
+}

--- a/src/event-emitter-to-async-iterable.ts
+++ b/src/event-emitter-to-async-iterable.ts
@@ -5,6 +5,7 @@ import { eventEmitterAsyncIterator } from './event-emitter-to-async-iterator';
 
 export function eventEmitterAsyncIterable<T>(eventEmitter: EventEmitter,
                                              eventsNames: string | string[]): AsyncIterable<T> {
+  // @ts-ignore: $$asyncIterator is considered the same as Symbol.asyncIterator by TypeScript
   return {
     [$$asyncIterator]() {
       return eventEmitterAsyncIterator(eventEmitter, eventsNames);

--- a/src/event-emitter-to-async-iterator.ts
+++ b/src/event-emitter-to-async-iterator.ts
@@ -65,6 +65,7 @@ export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
       return Promise.reject(error);
     },
     [$$asyncIterator]() {
+      console.warn('Using eventEmitterToAsyncIterator[$$asyncIterator]() (or using pubsub.asyncIterator as an async iterable) can leave dangling listeners and has been deprecated.  Use eventEmitterToAsyncIterable/pubsub.asyncIterable instead.')
       return this;
     },
   };

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -3,4 +3,5 @@ export interface PubSubEngine {
   subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   unsubscribe(subId: number);
   asyncIterator<T>(triggers: string | string[]): AsyncIterator<T>;
+  asyncIterable<T>(triggers: string | string[]): AsyncIterable<T>;
 }

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { PubSubEngine } from './pubsub-engine';
 import { eventEmitterAsyncIterator } from './event-emitter-to-async-iterator';
+import { eventEmitterAsyncIterable } from './event-emitter-to-async-iterable';
 
 export interface PubSubOptions {
   eventEmitter?: EventEmitter;
@@ -39,5 +40,9 @@ export class PubSub implements PubSubEngine {
 
   public asyncIterator<T>(triggers: string | string[]): AsyncIterator<T> {
     return eventEmitterAsyncIterator<T>(this.ee, triggers);
+  }
+
+  public asyncIterable<T>(triggers: string | string[]): AsyncIterable<T> {
+    return eventEmitterAsyncIterable<T>(this.ee, triggers);
   }
 }

--- a/src/test/asyncIterableSubscription.ts
+++ b/src/test/asyncIterableSubscription.ts
@@ -1,0 +1,167 @@
+// chai style expect().to.be.true  violates no-unused-expression
+/* tslint:disable:no-unused-expression */
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinonChai from 'sinon-chai';
+
+import { isAsyncIterable } from 'iterall';
+import { PubSub } from '../pubsub';
+import { withFilter, FilterFn } from '../with-filter';
+import { ExecutionResult } from 'graphql';
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+const expect = chai.expect;
+
+import {
+  parse,
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+import { subscribe } from 'graphql/subscription';
+
+const FIRST_EVENT = 'FIRST_EVENT';
+
+const defaultFilter = (payload) => true;
+
+function buildSchema(iterable, filterFn: FilterFn = defaultFilter) {
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        testString: {
+          type: GraphQLString,
+          resolve: function(_, args) {
+            return 'works';
+          },
+        },
+      },
+    }),
+    subscription: new GraphQLObjectType({
+      name: 'Subscription',
+      fields: {
+        testSubscription: {
+          type: GraphQLString,
+          subscribe: withFilter(() => iterable, filterFn),
+          resolve: root => {
+            return 'FIRST_EVENT';
+          },
+        },
+      },
+    }),
+  });
+}
+
+describe('GraphQL-JS asyncIterable', () => {
+  it('should allow subscriptions', async () => {
+    const query = parse(`
+      subscription S1 {
+
+        testSubscription
+      }
+    `);
+    const pubsub = new PubSub();
+    const origIterable = pubsub.asyncIterable(FIRST_EVENT);
+    const schema = buildSchema(origIterable);
+
+
+    const results = await subscribe(schema, query) as AsyncIterator<ExecutionResult>;
+    const payload1 = results.next();
+
+    expect(isAsyncIterable(results)).to.be.true;
+
+    const r = payload1.then(res => {
+      expect(res.value.data.testSubscription).to.equal('FIRST_EVENT');
+    });
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return r;
+  });
+
+  it('should allow async filter', async () => {
+    const query = parse(`
+      subscription S1 {
+
+        testSubscription
+      }
+    `);
+    const pubsub = new PubSub();
+    const origIterable = pubsub.asyncIterable(FIRST_EVENT);
+    const schema = buildSchema(origIterable, () => Promise.resolve(true));
+
+    const results = await subscribe(schema, query) as AsyncIterator<ExecutionResult>;
+    const payload1 = results.next();
+
+    expect(isAsyncIterable(results)).to.be.true;
+
+    const r = payload1.then(res => {
+      expect(res.value.data.testSubscription).to.equal('FIRST_EVENT');
+    });
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return r;
+  });
+
+  it('should detect when the payload is done when filtering', (done) => {
+    const query = parse(`
+      subscription S1 {
+        testSubscription
+      }
+    `);
+
+    const pubsub = new PubSub();
+    const origIterable = pubsub.asyncIterable(FIRST_EVENT);
+
+    let counter = 0;
+
+    const filterFn = () => {
+      counter++;
+
+      if (counter > 10) {
+        const e = new Error('Infinite loop detected');
+        done(e);
+        throw e;
+      }
+
+      return false;
+    };
+
+    const schema = buildSchema(origIterable, filterFn);
+
+    Promise.resolve(subscribe(schema, query)).then((results: AsyncIterator<ExecutionResult>) => {
+      expect(isAsyncIterable(results)).to.be.true;
+
+      results.next();
+      results.return();
+
+      pubsub.publish(FIRST_EVENT, {});
+
+      setTimeout(_ => {
+        done();
+      }, 500);
+    });
+  });
+
+  it('should clear event handlers', async () => {
+    const query = parse(`
+      subscription S1 {
+        testSubscription
+      }
+    `);
+
+    const pubsub = new PubSub();
+    const origIterable = pubsub.asyncIterable(FIRST_EVENT);
+    const schema = buildSchema(origIterable);
+
+    const results = await subscribe(schema, query) as AsyncIterator<ExecutionResult>;
+    const end = results.return();
+
+    pubsub.publish(FIRST_EVENT, {});
+
+    return end;
+  });
+});

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,41 +1,45 @@
-import { $$asyncIterator } from 'iterall';
+import { $$asyncIterator, getAsyncIterator } from 'iterall';
 
 export type FilterFn = (rootValue?: any, args?: any, context?: any, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterator<any>;
+export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterable<any>;
 
-export const withFilter = (asyncIteratorFn: ResolverFn, filterFn: FilterFn): ResolverFn => {
-  return (rootValue: any, args: any, context: any, info: any): AsyncIterator<any> => {
-    const asyncIterator = asyncIteratorFn(rootValue, args, context, info);
+export const withFilter = (asyncIterableFn: ResolverFn, filterFn: FilterFn): ResolverFn => {
+  return (rootValue: any, args: any, context: any, info: any): AsyncIterable<any> => {
+    const asyncIterable = asyncIterableFn(rootValue, args, context, info);
 
-    const getNextPromise = () => {
-      return asyncIterator
-        .next()
-        .then(payload => Promise.all([
-          payload,
-          Promise.resolve(filterFn(payload.value, args, context, info)).catch(() => false),
-        ]))
-        .then(([payload, filterResult]) => {
-          if (filterResult === true || payload.done === true) {
-            return payload;
-          }
-
-          // Skip the current value and wait for the next one
-          return getNextPromise();
-        });
-    };
-
+    // @ts-ignore: $$asyncIterator is considered the same as Symbol.asyncIterator by TypeScript
     return {
-      next() {
-        return getNextPromise();
-      },
-      return() {
-        return asyncIterator.return();
-      },
-      throw(error) {
-        return asyncIterator.throw(error);
-      },
       [$$asyncIterator]() {
-        return this;
+        const asyncIterator = getAsyncIterator(asyncIterable);
+
+        const getNextPromise = () => {
+          return asyncIterator
+            .next()
+            .then(payload => Promise.all([
+              payload,
+              Promise.resolve(filterFn(payload.value, args, context, info)).catch(() => false),
+            ]))
+            .then(([payload, filterResult]) => {
+              if (filterResult === true || payload.done === true) {
+                return payload;
+              }
+
+              // Skip the current value and wait for the next one
+              return getNextPromise();
+            });
+        };
+
+        return {
+          next() {
+            return getNextPromise();
+          },
+          return() {
+            return asyncIterator.return();
+          },
+          throw(error) {
+            return asyncIterator.throw(error);
+          },
+        };
       },
     };
   };


### PR DESCRIPTION
As @jquense wisely helped me realize in #143, `pubsub.asyncIterator` is unsafe and could leave dangling event listeners when consumed by 3rd-party code.

In general the documentation mistakenly states that GraphQL `subscribe` resolvers must return an `AsyncIterator`; rather, they should return an `AsyncIterable`, and event listener registration/anything else necessitating cleanup should only be performed when that `AsyncIterable`'s `Symbol.asyncIterator` method is actually called, since `for await` and probably most 3rd-party code is only guaranteed to `return` the iterator if it ends up starting iteration (i.e. calling `Symbol.asyncIterator`).

As a solution, I've created a new `pubsub.asyncIterable` method that we should advise people to use.  I also made `eventEmitterToAsyncIterator` print a deprecation warning when it's used like an `AsyncIterable` (which will happen with the current recommended usage of `pubsub.asyncIterator`).

The `withFilter` method still needs to be redesigned to operate on `AsyncIterable`s instead of `AsyncIterators`.