### PR TITLE
Fix #160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ### vNEXT
+- BREAKING CHANGE: Changed return type of `publish`. [Issue #160] (https://github.com/apollographql/graphql-subscriptions/issues/160)
+- Bump versions of various devDependencies to fix security issues, use newer tslint config [PR #163] (https://github.com/apollographql/graphql-subscriptions/pull/163)
+[PR #164] (https://github.com/apollographql/graphql-subscriptions/pull/164)
 
 ### 0.5.8
 - Bump iterall version

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -1,5 +1,5 @@
 export interface PubSubEngine {
-  publish(triggerName: string, payload: any): boolean;
+  publish(triggerName: string, payload: any): Promise<void>;
   subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   unsubscribe(subId: number);
   asyncIterator<T>(triggers: string | string[]): AsyncIterator<T>;

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -17,10 +17,9 @@ export class PubSub implements PubSubEngine {
     this.subIdCounter = 0;
   }
 
-  public publish(triggerName: string, payload: any): boolean {
+  public publish(triggerName: string, payload: any): Promise<void> {
     this.ee.emit(triggerName, payload);
-
-    return true;
+    return Promise.resolve();
   }
 
   public subscribe(triggerName: string, onMessage: (...args: any[]) => void): Promise<number> {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -26,17 +26,12 @@ describe('PubSub', function() {
     });
   });
 
-  it('can unsubscribe', function(done) {
+  it('can unsubscribe', async () => {
     const ps = new PubSub();
-    ps.subscribe('a', payload => {
-      assert(false);
-    }).then((subId) => {
-      ps.unsubscribe(subId);
-      const succeed = ps.publish('a', 'test');
-      expect(succeed).to.be.true; // True because publish success is not
-                                  // indicated by trigger having subscriptions
-      done(); // works because pubsub is synchronous
-    });
+    let subId = await ps.subscribe('a', payload => { assert(false); });
+    ps.unsubscribe(subId);
+    let succeed = await ps.publish('a', 'test');
+    expect(succeed).to.be.undefined;
   });
 });
 

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -41,18 +41,18 @@ describe('PubSub', function() {
 });
 
 describe('AsyncIterator', () => {
-  it('should expose valid asyncItrator for a specific event', () => {
-    const evnetName = 'test';
+  it('should expose valid asyncIterator for a specific event', () => {
+    const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(evnetName);
+    const iterator = ps.asyncIterator(eventName);
     expect(iterator).to.not.be.undefined;
     expect(isAsyncIterable(iterator)).to.be.true;
   });
 
   it('should trigger event on asyncIterator when published', done => {
-    const evnetName = 'test';
+    const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(evnetName);
+    const iterator = ps.asyncIterator(eventName);
 
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
@@ -61,22 +61,22 @@ describe('AsyncIterator', () => {
       done();
     });
 
-    ps.publish(evnetName, { test: true });
+    ps.publish(eventName, { test: true });
   });
 
   it('should not trigger event on asyncIterator when publishing other event', () => {
-    const evnetName = 'test2';
+    const eventName = 'test2';
     const ps = new PubSub();
     const iterator = ps.asyncIterator('test');
     const spy = sinon.spy();
 
     iterator.next().then(spy);
-    ps.publish(evnetName, { test: true });
+    ps.publish(eventName, { test: true });
     expect(spy).not.to.have.been.called;
   });
 
   it('register to multiple events', done => {
-    const evnetName = 'test2';
+    const eventName = 'test2';
     const ps = new PubSub();
     const iterator = ps.asyncIterator(['test', 'test2']);
     const spy = sinon.spy();
@@ -86,13 +86,13 @@ describe('AsyncIterator', () => {
       expect(spy).to.have.been.called;
       done();
     });
-    ps.publish(evnetName, { test: true });
+    ps.publish(eventName, { test: true });
   });
 
   it('should not trigger event on asyncIterator already returned', done => {
-    const evnetName = 'test';
+    const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(evnetName);
+    const iterator = ps.asyncIterator(eventName);
 
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
@@ -100,7 +100,7 @@ describe('AsyncIterator', () => {
       expect(result.done).to.be.false;
     });
 
-    ps.publish(evnetName, { test: true });
+    ps.publish(eventName, { test: true });
 
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
@@ -111,6 +111,6 @@ describe('AsyncIterator', () => {
 
     iterator.return();
 
-    ps.publish(evnetName, { test: true });
+    ps.publish(eventName, { test: true });
   });
 });


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

See discussion in #160