### PR TITLE
Version bump and changelog updates, prepping for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
+- "10"
 - "8"
 - "6"
-- "4"
+
 install:
 - npm install -g coveralls
 - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
-### vNEXT
-- BREAKING CHANGE: Changed return type of `publish`. [Issue #160] (https://github.com/apollographql/graphql-subscriptions/issues/160)
-- Bump versions of various devDependencies to fix security issues, use newer tslint config [PR #163] (https://github.com/apollographql/graphql-subscriptions/pull/163)
-[PR #164] (https://github.com/apollographql/graphql-subscriptions/pull/164)
+### 1.0.0
+
+- BREAKING CHANGE: Changed return type of `publish`.  <br/>
+  [@grantwwu](https://github.com/grantwwu) in [#162](https://github.com/apollographql/graphql-subscriptions/pull/162)
+- Bump versions of various devDependencies to fix security issues, use
+  newer tslint config.  <br/>
+  [@grantwwu](https://github.com/grantwwu) in [#163](https://github.com/apollographql/graphql-subscriptions/pull/163)
+- Allows `graphql` 14 as a peer dep, forces `graphql` 14 as a dev dep, and
+  has been updated to use `@types/graphql` 14.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#]()
 
 ### 0.5.8
 - Bump iterall version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   [@grantwwu](https://github.com/grantwwu) in [#163](https://github.com/apollographql/graphql-subscriptions/pull/163)
 - Allows `graphql` 14 as a peer dep, forces `graphql` 14 as a dev dep, and
   has been updated to use `@types/graphql` 14.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#]()
+  [@hwillson](https://github.com/hwillson) in [#172](https://github.com/apollographql/graphql-subscriptions/pull/172)
 
 ### 0.5.8
 - Bump iterall version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-subscriptions",
-  "version": "0.5.8",
+  "version": "1.0.0",
   "description": "GraphQL subscriptions for node.js",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
@NeoPhi I'd like to push out a new `graphql-subscriptions` release as soon as possible (to get the changes from https://github.com/apollographql/graphql-subscriptions/pull/171 in place). I see in the changelog that there is currently a breaking change waiting to be released. Do you have any issues with me bumping to 1.0.0 and publishing? Thanks!