### PR TITLE
Allow to pass symbols as event names

### DIFF
--- a/src/event-emitter-to-async-iterator.ts
+++ b/src/event-emitter-to-async-iterator.ts
@@ -5,7 +5,7 @@ export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
                                              eventsNames: string | string[]): AsyncIterator<T> {
   const pullQueue = [];
   const pushQueue = [];
-  const eventsArray = typeof eventsNames === 'string' ? [eventsNames] : eventsNames;
+  const eventsArray = /(string|symbol)/.test(typeof eventsNames) ? [eventsNames] : eventsNames;
   let listening = true;
 
   const pushValue = event => {


### PR DESCRIPTION
Hi and thanks for this package,
Node's EventEmitters allows strings and symbols as event names, this change allows it for PubSub as well.
Cheers


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->