### PR TITLE
Refactor async event emitter

### DIFF
--- a/src/event-emitter-to-async-iterator.ts
+++ b/src/event-emitter-to-async-iterator.ts
@@ -2,13 +2,13 @@ import { EventEmitter } from 'events';
 
 export async function* eventEmitterAsyncIterator<T>(
   emitter: EventEmitter,
-  event: string | string[]
+  events: string | string[]
 ): AsyncIterator<T> {
   let q = [];
-  const events = [].concat(event);
-  events.forEach(e => emitter.on(e, arg => q.push(arg)));
+  const eventsArray = [].concat(events);
+  for (let event of eventsArray) emitter.on(event,arg => q.push(arg));
   while (true) {
-    await Promise.race(events.map(e => new Promise(rs => emitter.once(e, rs))));
+    await new Promise(rs=>setImmediate(rs));
     while (q.length) {
       yield q.shift();
     }

--- a/src/event-emitter-to-async-iterator.ts
+++ b/src/event-emitter-to-async-iterator.ts
@@ -1,75 +1,16 @@
-import { $$asyncIterator } from 'iterall';
-import { EventEmitter } from 'events';
+import { EventEmitter } from "events";
 
-export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
-                                             eventsNames: string | string[]): AsyncIterator<T> {
-  const pullQueue = [];
-  const pushQueue = [];
-  const eventsArray = typeof eventsNames === 'string' ? [eventsNames] : eventsNames;
-  let listening = true;
-  let addedListeners = false;
-
-  const pushValue = event => {
-    if (pullQueue.length !== 0) {
-      pullQueue.shift()({ value: event, done: false });
-    } else {
-      pushQueue.push(event);
+export async function* eventEmitterAsyncIterator<T>(
+  emitter: EventEmitter,
+  event: string | string[]
+): AsyncIterator<T> {
+  let q = [];
+  const events = [].concat(event);
+  events.forEach(e => emitter.on(e, arg => q.push(arg)));
+  while (true) {
+    await Promise.race(events.map(e => new Promise(rs => emitter.once(e, rs))));
+    while (q.length) {
+      yield q.shift();
     }
-  };
-
-  const pullValue = () => {
-    return new Promise(resolve => {
-      if (pushQueue.length !== 0) {
-        resolve({ value: pushQueue.shift(), done: false });
-      } else {
-        pullQueue.push(resolve);
-      }
-    });
-  };
-
-  const emptyQueue = () => {
-    if (listening) {
-      listening = false;
-      if (addedListeners) { removeEventListeners(); }
-      pullQueue.forEach(resolve => resolve({ value: undefined, done: true }));
-      pullQueue.length = 0;
-      pushQueue.length = 0;
-    }
-  };
-
-  const addEventListeners = () => {
-    for (const eventName of eventsArray) {
-      eventEmitter.addListener(eventName, pushValue);
-    }
-  };
-
-  const removeEventListeners = () => {
-    for (const eventName of eventsArray) {
-      eventEmitter.removeListener(eventName, pushValue);
-    }
-  };
-
-  return {
-    next() {
-      if (!listening) { return this.return(); }
-      if (!addedListeners) {
-        addEventListeners();
-        addedListeners = true;
-      }
-      return pullValue();
-    },
-    return() {
-      emptyQueue();
-
-      return Promise.resolve({ value: undefined, done: true });
-    },
-    throw(error) {
-      emptyQueue();
-
-      return Promise.reject(error);
-    },
-    [$$asyncIterator]() {
-      return this;
-    },
-  };
+  }
 }

--- a/src/event-emitter-to-async-iterator.ts
+++ b/src/event-emitter-to-async-iterator.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from 'events';
 
 export async function* eventEmitterAsyncIterator<T>(
   emitter: EventEmitter,

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -95,6 +95,8 @@ describe('AsyncIterator', () => {
 
     ps.publish(eventName, { test: true });
 
+    iterator.return();
+
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
       expect(result.value).to.be.undefined;
@@ -102,7 +104,6 @@ describe('AsyncIterator', () => {
       done();
     });
 
-    iterator.return();
 
     ps.publish(eventName, { test: true });
   });


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This PR greatly reduces the complexity of `src/event-emitter-to-async-iterator` but relies on changes to `src/test/test.js` and could use additional input on how to handle the unsubscription of events on the given event emitter. `return()` should otherwise unsubscribe the listener but does not in this PR.