### PR TITLE
Change methods/types from AsyncIterator to AsyncIterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+.idea
 coverage
 dist
 node_modules

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import { PubSub } from 'graphql-subscriptions';
 export const pubsub = new PubSub();
 ```
 
-Now, implement your Subscriptions type resolver, using the `pubsub.asyncIterator` to map the event you need:
+Now, implement your Subscriptions type resolver, using `pubsub.asyncIterable` to map the event you need:
 
 ```js
 const SOMETHING_CHANGED_TOPIC = 'something_changed';
@@ -60,7 +60,7 @@ const SOMETHING_CHANGED_TOPIC = 'something_changed';
 export const resolvers = {
   Subscription: {
     somethingChanged: {
-      subscribe: () => pubsub.asyncIterator(SOMETHING_CHANGED_TOPIC),
+      subscribe: () => pubsub.asyncIterable(SOMETHING_CHANGED_TOPIC),
     },
   },
 }
@@ -81,10 +81,10 @@ pubsub.publish(SOMETHING_CHANGED_TOPIC, { somethingChanged: { id: "123" }});
 
 When publishing data to subscribers, we need to make sure that each subscribers get only the data it need.
 
-To do so, we can use `withFilter` helper from this package, which wraps `AsyncIterator` with a filter function, and let you control each publication for each user.
+To do so, we can use `withFilter` helper from this package, which wraps `AsyncIterable` with a filter function, and let you control each publication for each user.
 
 `withFilter` API:
-- `asyncIteratorFn: (rootValue, args, context, info) => AsyncIterator<any>` : A function that returns `AsyncIterator` you got from your `pubsub.asyncIterator`.
+- `asyncIterableFn: (rootValue, args, context, info) => AsyncIterable<any>` : A function that returns `AsyncIterable` you got from your `pubsub.asyncIterable`.
 - `filterFn: (payload, variables, context, info) => boolean | Promise<boolean>` - A filter function, executed with the payload (the published value), variables, context and operation info, must return `boolean` or `Promise<boolean>` indicating if the payload should pass to the subscriber.
 
 For example, if `somethingChanged` would also accept a variable with the ID that is relevant, we can use the following code to filter according to it:
@@ -97,7 +97,7 @@ const SOMETHING_CHANGED_TOPIC = 'something_changed';
 export const resolvers = {
   Subscription: {
     somethingChanged: {
-      subscribe: withFilter(() => pubsub.asyncIterator(SOMETHING_CHANGED_TOPIC), (payload, variables) => {
+      subscribe: withFilter(() => pubsub.asyncIterable(SOMETHING_CHANGED_TOPIC), (payload, variables) => {
         return payload.somethingChanged.id === variables.relevantId;
       }),
     },
@@ -119,7 +119,7 @@ const SOMETHING_REMOVED = 'something_removed';
 export const resolvers = {
   Subscription: {
     somethingChanged: {
-      subscribe: () => pubsub.asyncIterator([ SOMETHING_UPDATED, SOMETHING_CREATED, SOMETHING_REMOVED ]),
+      subscribe: () => pubsub.asyncIterable([ SOMETHING_UPDATED, SOMETHING_CREATED, SOMETHING_REMOVED ]),
     },
   },
 }
@@ -139,7 +139,7 @@ export const resolvers = {
         // Manipulate and return the new value
         return payload.somethingChanged;
       },
-      subscribe: () => pubsub.asyncIterator(SOMETHING_UPDATED),
+      subscribe: () => pubsub.asyncIterable(SOMETHING_UPDATED),
     },
   },
 }
@@ -176,20 +176,20 @@ export const resolvers = {
 }
 ````
 
-### Custom `AsyncIterator` Wrappers
+### Custom `AsyncIterable` Wrappers
 
-The value you should return from your `subscribe` resolver must be an `AsyncIterator`.
+The value you should return from your `subscribe` resolver must be an `AsyncIterable`.
 
-You can use this value and wrap it with another `AsyncIterator` to implement custom logic over your subscriptions.
+You can use this value and wrap it with another `AsyncIterable` to implement custom logic over your subscriptions.
 
 For example, the following implementation manipulate the payload by adding some static fields:
 
 ```typescript
-import { $$asyncIterator } from 'iterall';
+import { $$asyncIterator, getAsyncIterator } from 'iterall';
 
-export const withStaticFields = (asyncIterator: AsyncIterator<any>, staticFields: Object): Function => {
-  return (rootValue: any, args: any, context: any, info: any): AsyncIterator<any> => {
-
+export const withStaticFields = (asyncIterable: AsyncIterable<any>, staticFields: Object): Function => {
+  return (rootValue: any, args: any, context: any, info: any): AsyncIterable<any> => {
+    const asyncIterator = getAsyncIterator(asyncIterable);
     return {
       next() {
         return asyncIterator.next().then(({ value, done }) => {
@@ -211,14 +211,14 @@ export const withStaticFields = (asyncIterator: AsyncIterator<any>, staticFields
       [$$asyncIterator]() {
         return this;
       },
-    };
+    } as AsyncIterator<any> as AsyncIterableIterator<any>;
   };
 };
 ```
 
 > You can also take a look at `withFilter` for inspiration.
 
-For more information about `AsyncIterator`:
+For more information about `AsyncIterable` and `AsyncIterator`:
 - [TC39 Proposal](https://github.com/tc39/proposal-async-iteration)
 - [iterall](https://github.com/leebyron/iterall)
 - [IxJS](https://github.com/ReactiveX/IxJS)

--- a/src/event-emitter-to-async-iterable.ts
+++ b/src/event-emitter-to-async-iterable.ts
@@ -1,8 +1,8 @@
 import { $$asyncIterator } from 'iterall';
 import { EventEmitter } from 'events';
 
-export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
-                                             eventsNames: string | string[]): AsyncIterator<T> {
+export function eventEmitterAsyncIterable<T>(eventEmitter: EventEmitter,
+                                             eventsNames: string | string[]): AsyncIterableIterator<T> {
   const pullQueue = [];
   const pushQueue = [];
   const eventsArray = typeof eventsNames === 'string' ? [eventsNames] : eventsNames;
@@ -71,5 +71,6 @@ export function eventEmitterAsyncIterator<T>(eventEmitter: EventEmitter,
     [$$asyncIterator]() {
       return this;
     },
-  };
+  } as AsyncIterator<T> as any as AsyncIterableIterator<T>;
+  // Asserting as AsyncIterator first so that next, return, and throw are still type checked
 }

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -2,5 +2,5 @@ export interface PubSubEngine {
   publish(triggerName: string, payload: any): Promise<void>;
   subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   unsubscribe(subId: number);
-  asyncIterator<T>(triggers: string | string[]): AsyncIterator<T>;
+  asyncIterable<T>(triggers: string | string[]): AsyncIterable<T>;
 }

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { PubSubEngine } from './pubsub-engine';
-import { eventEmitterAsyncIterator } from './event-emitter-to-async-iterator';
+import { eventEmitterAsyncIterable } from './event-emitter-to-async-iterable';
 
 export interface PubSubOptions {
   eventEmitter?: EventEmitter;
@@ -36,7 +36,7 @@ export class PubSub implements PubSubEngine {
     this.ee.removeListener(triggerName, onMessage);
   }
 
-  public asyncIterator<T>(triggers: string | string[]): AsyncIterator<T> {
-    return eventEmitterAsyncIterator<T>(this.ee, triggers);
+  public asyncIterable<T>(triggers: string | string[]): AsyncIterable<T> {
+    return eventEmitterAsyncIterable<T>(this.ee, triggers);
   }
 }

--- a/src/test/asyncIteratorSubscription.ts
+++ b/src/test/asyncIteratorSubscription.ts
@@ -5,7 +5,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import { spy } from 'sinon';
 import * as sinonChai from 'sinon-chai';
 
-import { isAsyncIterable } from 'iterall';
+import { getAsyncIterator, isAsyncIterable } from 'iterall';
 import { PubSub } from '../pubsub';
 import { withFilter, FilterFn } from '../with-filter';
 import { ExecutionResult } from 'graphql';
@@ -64,7 +64,7 @@ describe('GraphQL-JS asyncIterator', () => {
       }
     `);
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterable(FIRST_EVENT);
     const schema = buildSchema(origIterator);
 
 
@@ -90,7 +90,7 @@ describe('GraphQL-JS asyncIterator', () => {
       }
     `);
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterable(FIRST_EVENT);
     const schema = buildSchema(origIterator, () => Promise.resolve(true));
 
     const results = await subscribe(schema, query) as AsyncIterator<ExecutionResult>;
@@ -115,7 +115,7 @@ describe('GraphQL-JS asyncIterator', () => {
     `);
 
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterable(FIRST_EVENT);
 
     let counter = 0;
 
@@ -155,7 +155,8 @@ describe('GraphQL-JS asyncIterator', () => {
     `);
 
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterable = pubsub.asyncIterable(FIRST_EVENT);
+    const origIterator = getAsyncIterator(origIterable);
     const returnSpy = spy(origIterator, 'return');
     const schema = buildSchema(origIterator);
 

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -7,7 +7,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as sinonChai from 'sinon-chai';
 
 import { PubSub } from '../pubsub';
-import { isAsyncIterable } from 'iterall';
+import { getAsyncIterator, isAsyncIterable } from 'iterall';
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -37,7 +37,7 @@ describe('AsyncIterator', () => {
   it('should expose valid asyncIterator for a specific event', () => {
     const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(eventName);
+    const iterator = ps.asyncIterable(eventName);
     expect(iterator).to.not.be.undefined;
     expect(isAsyncIterable(iterator)).to.be.true;
   });
@@ -45,7 +45,7 @@ describe('AsyncIterator', () => {
   it('should trigger event on asyncIterator when published', done => {
     const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(eventName);
+    const iterator = getAsyncIterator(ps.asyncIterable(eventName));
 
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
@@ -60,7 +60,7 @@ describe('AsyncIterator', () => {
   it('should not trigger event on asyncIterator when publishing other event', () => {
     const eventName = 'test2';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator('test');
+    const iterator = getAsyncIterator(ps.asyncIterable('test'));
     const spy = sinon.spy();
 
     iterator.next().then(spy);
@@ -71,7 +71,7 @@ describe('AsyncIterator', () => {
   it('register to multiple events', done => {
     const eventName = 'test2';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(['test', 'test2']);
+    const iterator = getAsyncIterator(ps.asyncIterable(['test', 'test2']));
     const spy = sinon.spy();
 
     iterator.next().then(() => {
@@ -85,7 +85,7 @@ describe('AsyncIterator', () => {
   it('should not trigger event on asyncIterator already returned', done => {
     const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(eventName);
+    const iterator = getAsyncIterator(ps.asyncIterable(eventName));
 
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
@@ -115,7 +115,7 @@ describe('AsyncIterator', () => {
       }
     }
     const ps = new TestPubSub();
-    ps.asyncIterator(testEventName);
+    ps.asyncIterable(testEventName);
 
     expect(ps.listenerCount(testEventName)).to.equal(0);
   });

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,11 +1,12 @@
-import { $$asyncIterator } from 'iterall';
+import { $$asyncIterator, getAsyncIterator } from 'iterall';
 
 export type FilterFn = (rootValue?: any, args?: any, context?: any, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterator<any>;
+export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterable<any>;
 
-export const withFilter = (asyncIteratorFn: ResolverFn, filterFn: FilterFn): ResolverFn => {
-  return (rootValue: any, args: any, context: any, info: any): AsyncIterator<any> => {
-    const asyncIterator = asyncIteratorFn(rootValue, args, context, info);
+export const withFilter = (asyncIterableFn: ResolverFn, filterFn: FilterFn): ResolverFn => {
+  return (rootValue: any, args: any, context: any, info: any): AsyncIterableIterator<any> => {
+    const asyncIterable = asyncIterableFn(rootValue, args, context, info);
+    const asyncIterator = getAsyncIterator(asyncIterable);
 
     const getNextPromise = () => {
       return asyncIterator
@@ -41,6 +42,7 @@ export const withFilter = (asyncIteratorFn: ResolverFn, filterFn: FilterFn): Res
       [$$asyncIterator]() {
         return this;
       },
-    };
+    } as AsyncIterator<any> as any as AsyncIterableIterator<any>;
+    // Asserting as AsyncIterator first so that next, return, and throw are still type checked
   };
 };


### PR DESCRIPTION
After opening #192, I looked into it more and saw that graphql-js is actually expecting an Async**Iterable**, not Async**Iterator**, to be returned from the `subscribe` function: [source](https://github.com/graphql/graphql-js/blob/master/src/subscription/subscribe.js#L277).

This PR updates the types, methods, and docs to reflect that. This is a breaking change. As mentioned in https://github.com/leebyron/iterall/issues/49, TS can't recognize `$$asyncIterator` as `Symbol.asyncIterator`, so type assertions had to be used in a few places

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->