### PR TITLE
Allow withFilter asyncIteratorFn to return Promise

### DIFF
--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,11 +1,11 @@
 import { $$asyncIterator } from 'iterall';
 
 export type FilterFn = (rootValue?: any, args?: any, context?: any, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterator<any>;
+export type ResolverFn = (rootValue?: any, args?: any, context?: any, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
 
 export const withFilter = (asyncIteratorFn: ResolverFn, filterFn: FilterFn): ResolverFn => {
-  return (rootValue: any, args: any, context: any, info: any): AsyncIterator<any> => {
-    const asyncIterator = asyncIteratorFn(rootValue, args, context, info);
+  return async (rootValue: any, args: any, context: any, info: any): Promise<AsyncIterator<any>> => {
+    const asyncIterator = await asyncIteratorFn(rootValue, args, context, info);
 
     const getNextPromise = () => {
       return asyncIterator


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Use case: `asyncIteratorFn` is place where I want to authorize the subscription, authorization should not be implemented in GraphQL resolvers, I want to delegate authorization logic to the business layer which is in our case implemented in another service, that is why I need to change result of ResolverFn to `Promise<AsyncIterator<any>>` to be able to await for the result of the service call in asyncIteratorFn handler