### PR TITLE
Add a check such that next can be called after a return (fixes #201)

### DIFF
--- a/src/pubsub-async-iterator.ts
+++ b/src/pubsub-async-iterator.ts
@@ -52,8 +52,10 @@ export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
   }
 
   public async next(): Promise<IteratorResult<T>> {
-    if (!this.allSubscribed) { await (this.allSubscribed = this.subscribeAll()); }
-    return this.pullValue();
+    if (this.running && !this.allSubscribed) {
+      await (this.allSubscribed = this.subscribeAll());
+    }
+    return this.running ? this.pullValue() : this.return();
   }
 
   public async return(): Promise<IteratorResult<T>> {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -8,6 +8,7 @@ import * as sinonChai from 'sinon-chai';
 
 import { PubSub } from '../pubsub';
 import { isAsyncIterable } from 'iterall';
+import { doesNotThrow } from 'assert';
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -120,5 +121,14 @@ describe('AsyncIterator', () => {
     ps.asyncIterator(testEventName);
 
     expect(ps.listenerCount(testEventName)).to.equal(0);
+  });
+  it('should allow returning before next() is called', async () => {
+    const testEventName = 'test';
+    const ps = new PubSub();
+    const ai = ps.asyncIterator(testEventName);
+    const promise = ai.next();
+    ai.return();
+    await promise;
+    expect(promise).to.eventually.deep.equal({ value: undefined, done: true });
   });
 });


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Have `next` check that the async iterator hasn't already completed.