### PR TITLE
Fix memory leak in withFilter cause by recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "posttest": "npm run lint",
     "lint": "tslint --project ./tsconfig.json ./src/**/*.ts",
     "watch": "tsc -w",
-    "testonly": "mocha --expose-gc --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
-    "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
+    "testonly": "node --expose-gc ./node_modules/.bin/mocha --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
+    "coverage": "node --expose-gc ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
     "prepublishOnly": "npm run clean && npm run compile"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "posttest": "npm run lint",
     "lint": "tslint --project ./tsconfig.json ./src/**/*.ts",
     "watch": "tsc -w",
-    "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
+    "testonly": "mocha --expose-gc --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
     "prepublishOnly": "npm run clean && npm run compile"

--- a/src/test/asyncIteratorSubscription.ts
+++ b/src/test/asyncIteratorSubscription.ts
@@ -133,8 +133,9 @@ describe('GraphQL-JS asyncIterator', () => {
 
     const schema = buildSchema(origIterator, filterFn);
 
-    Promise.resolve(subscribe(schema, query)).then((results: AsyncIterator<ExecutionResult>) => {
-      expect(isAsyncIterable(results)).to.be.true;
+    subscribe(schema, query).then((resultsIn) => {
+      expect(isAsyncIterable(resultsIn)).to.be.true;
+      const results = resultsIn as AsyncIterator<ExecutionResult>;
 
       results.next();
       results.return();

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -41,7 +41,7 @@ export const withFilter = (asyncIteratorFn: ResolverFn, filterFn: FilterFn): Res
       });
     };
 
-    return {
+    const asyncIterator2 = {
       next() {
         return getNextPromise();
       },
@@ -55,5 +55,7 @@ export const withFilter = (asyncIteratorFn: ResolverFn, filterFn: FilterFn): Res
         return this;
       },
     };
+
+    return asyncIterator2;
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "pretty": true,
     "removeComments": true,
     "declaration": true,
+    "skipLibCheck": true,
     "typeRoots": ["node_modules/@types"]
   },
   "exclude": [


### PR DESCRIPTION
`withFilter` function is causing memory leak because of Promise spec. Related: https://github.com/nodejs/node/issues/6673.

This is a big problem when you have long living subscriber to subscription who skips most of messages (all Promises in recursion chain are kept in memory).

**How to reproduce:**

Start a subscriber to a subscription which rejects messages and start publishing messages. You'll notice memory keeps increasing. Memory profile will confirm.  
Do the same thing using refactored `withFilter` and you'll notice memory is not increasing.

**Pull Request Labels**

- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review


Fixes #212 