### PR TITLE
Adds AWS SNS SQS PubSub Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ It can be easily replaced with some other implementations of [PubSubEngine abstr
 - Use multiple backends with https://github.com/jcoreio/graphql-multiplex-subscriptions
 - Use Ably for multi-protocol support with https://github.com/ably-labs/graphql-ably-pubsub
 - Use Google Firestore with https://github.com/m19c/graphql-firestore-subscriptions
+- Use AWS' Simple Notification Service (SNS) and Simple Queue Service (SQS) with https://github.com/cto2bOpenSource/graphql-snssqs-subscriptions
 - [Add your implementation...](https://github.com/apollographql/graphql-subscriptions/pull/new/master)
 
 You can also implement a `PubSub` of your own, by using the exported abstract class `PubSubEngine` from this package. By using `extends PubSubEngine` you use the default `asyncIterator` method implementation; by using `implements PubSubEngine` you must implement your own `AsyncIterator`.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ It can be easily replaced with some other implementations of [PubSubEngine abstr
 - Use multiple backends with https://github.com/jcoreio/graphql-multiplex-subscriptions
 - Use Ably for multi-protocol support with https://github.com/ably-labs/graphql-ably-pubsub
 - Use Google Firestore with https://github.com/m19c/graphql-firestore-subscriptions
-- Use AWS' Simple Notification Service (SNS) and Simple Queue Service (SQS) with https://github.com/cto2bOpenSource/graphql-snssqs-subscriptions
+- Use Amazon's Simple Notification Service (SNS) and Simple Queue Service (SQS) with https://github.com/sagahead-io/graphql-snssqs-subscriptions
 - [Add your implementation...](https://github.com/apollographql/graphql-subscriptions/pull/new/master)
 
 You can also implement a `PubSub` of your own, by using the exported abstract class `PubSubEngine` from this package. By using `extends PubSubEngine` you use the default `asyncIterator` method implementation; by using `implements PubSubEngine` you must implement your own `AsyncIterator`.


### PR DESCRIPTION
Added AWS SNS + SQS PubSub Implementation.

Agreed with  https://contribute.apollographql.com/.

[NPM Package](https://www.npmjs.com/package/graphql-snssqs-subscriptions)