### PR TITLE
Allow resolver fn to be async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [@cursorsdottsx](https://github.com/cursorsdottsx) in [#245](https://github.com/apollographql/graphql-subscriptions/pull/245)
 - Support `readonly` arrays of event names. <br/>
   [@rh389](https://github.com/rh389) in [#234](https://github.com/apollographql/graphql-subscriptions/pull/234)
+- Support returning a Promise of an `AsyncIterator` as the `withFilter` resolver function. <br/>
+  [@maclockard](https://github.com/maclockard) in [#220](https://github.com/apollographql/graphql-subscriptions/pull/220)
 
 ### 2.0.1 (not yet released)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can use it with any GraphQL client and server (not only Apollo).
 
 If you are developing a project that uses this module with TypeScript:
 
-* ensure that your `tsconfig.json` `lib` definition includes `"esnext.asynciterable"`
+* ensure that your `tsconfig.json` `lib` definition includes `"es2018.asynciterable"`
 * `npm install @types/graphql` or `yarn add @types/graphql`
 
 ### Getting started with your first subscription

--- a/src/test/asyncIteratorSubscription.ts
+++ b/src/test/asyncIteratorSubscription.ts
@@ -189,7 +189,7 @@ const testFiniteAsyncIterator: AsyncIterableIterator<number> = (async function *
 
 describe('withFilter', () => {
   it('works properly with finite asyncIterators', async () => {
-    const filteredAsyncIterator = withFilter(() => testFiniteAsyncIterator, isEven)();
+    const filteredAsyncIterator = await withFilter(() => testFiniteAsyncIterator, isEven)();
 
     for (let i = 1; i <= 4; i++) {
       const result = await filteredAsyncIterator.next();
@@ -228,7 +228,8 @@ describe('withFilter', () => {
       },
     };
 
-    const filteredAsyncIterator = withFilter(() => asyncIterator, () => stopped)();
+    const filteredAsyncIterator =
+      await withFilter(() => asyncIterator, () => stopped)();
 
     global.gc();
     const heapUsed = process.memoryUsage().heapUsed;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -74,7 +74,7 @@ describe('AsyncIterator', () => {
   it('register to multiple events', done => {
     const eventName = 'test2';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(['test', 'test2'] as const);
+    const iterator = ps.asyncIterableIterator(['test', 'test2'] as const);
     const spy = sinon.spy();
 
     iterator.next().then(() => {

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,6 +1,5 @@
-
 export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any>;
+export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
 
 interface IterallAsyncIterator<T> extends AsyncIterableIterator<T> {
   [Symbol.asyncIterator](): IterallAsyncIterator<T>;
@@ -15,8 +14,8 @@ export function withFilter<TSource = any, TArgs = any, TContext = any>(
   asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
   filterFn: FilterFn<TSource, TArgs, TContext>
 ): ResolverFn<TSource, TArgs, TContext> {
-  return (rootValue: TSource, args: TArgs, context: TContext, info: any): IterallAsyncIterator<any> => {
-    const asyncIterator = asyncIteratorFn(rootValue, args, context, info);
+  return async (rootValue: TSource, args: TArgs, context: TContext, info: any): Promise<IterallAsyncIterator<any>> => {
+    const asyncIterator = await asyncIteratorFn(rootValue, args, context, info);
 
     const getNextPromise = () => {
       return new Promise<IteratorResult<any>>((resolve, reject) => {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Looking at some possible downstream consumers, these seems fine and not breaking since they can receive an async subscription function:

- https://github.com/graphql/graphql-js/blob/master/src/subscription/subscribe.d.ts#L42-L51
- https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/server.ts#L69-L78

fixes #213 