### PR TITLE
fix: updated graphql to 15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "iterall": "^1.2.1"
   },
   "peerDependencies": {
-    "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "scripts": {
     "clean": "rimraf dist coverage",
@@ -35,7 +35,7 @@
     "@types/sinon-chai": "^3.2.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "graphql": "^14.0.0",
+    "graphql": "^15.0.0",
     "istanbul": "^1.0.0-alpha.2",
     "mocha": "^5.2.0",
     "remap-istanbul": "^0.9.1",


### PR DESCRIPTION
Transition of this repo to graphql 14. This PR:

Allows graphql 14 as a peer dep
Forces graphql 14 as a dev dep

Note that `@types/graphql` is deprecated and should probably be removed. Hence it is not updated here