### PR TITLE
fix: Update to the library fork that is maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ For more information about `AsyncIterator`:
 It can be easily replaced with some other implementations of [PubSubEngine abstract class](https://github.com/apollographql/graphql-subscriptions/blob/master/src/pubsub-engine.ts). Here are a few of them:
 - Use Redis with https://github.com/davidyaha/graphql-redis-subscriptions
 - Use Google PubSub with https://github.com/axelspringer/graphql-google-pubsub
-- Use MQTT enabled broker with https://github.com/davidyaha/graphql-mqtt-subscriptions
+- Use MQTT enabled broker with https://github.com/aerogear/graphql-mqtt-subscriptions
 - Use RabbitMQ with https://github.com/cdmbase/graphql-rabbitmq-subscriptions
 - Use AMQP (RabbitMQ) with https://github.com/Surnet/graphql-amqp-subscriptions
 - Use Kafka with https://github.com/ancashoria/graphql-kafka-subscriptions


### PR DESCRIPTION
Original author of the library stopped maintaining it and it is no longer supporting latest versions of GraphQL

