### PR TITLE
feat: replace iterall with native Symbol.asyncIterator + fix return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add an optional generic type map to `PubSub`. <br/>
   [@cursorsdottsx](https://github.com/cursorsdottsx) in [#245](https://github.com/apollographql/graphql-subscriptions/pull/245)
+- Replace `iterall` use with native `Symbol.asyncIterator`. <br/>
+  [@n1ru4l](https://github.com/n1ru4l) in [#232](https://github.com/apollographql/graphql-subscriptions/pull/232)
 
 ### 2.0.1 (not yet released)
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "type": "git",
     "url": "https://github.com/apollostack/graphql-subscriptions.git"
   },
-  "dependencies": {
-    "iterall": "^1.3.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "graphql": "^15.7.2 || ^16.0.0"
   },

--- a/src/pubsub-async-iterable-iterator.ts
+++ b/src/pubsub-async-iterable-iterator.ts
@@ -1,4 +1,3 @@
-import { $$asyncIterator } from 'iterall';
 import { PubSubEngine } from './pubsub-engine';
 
 /**
@@ -33,7 +32,7 @@ import { PubSubEngine } from './pubsub-engine';
  * @property pubsub @type {PubSubEngine}
  * The PubSubEngine whose events will be observed.
  */
-export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
+export class PubSubAsyncIterableIterator<T> implements AsyncIterableIterator<T> {
 
   private pullQueue: ((value: IteratorResult<T>) => void)[];
   private pushQueue: T[];
@@ -66,7 +65,7 @@ export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
     return Promise.reject(error);
   }
 
-  public [$$asyncIterator]() {
+  public [Symbol.asyncIterator]() {
     return this;
   }
 
@@ -119,5 +118,4 @@ export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
       this.pubsub.unsubscribe(subscriptionId);
     }
   }
-
 }

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -4,7 +4,7 @@ export abstract class PubSubEngine {
   public abstract publish(triggerName: string, payload: any): Promise<void>;
   public abstract subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   public abstract unsubscribe(subId: number);
-  public asyncIterator<T>(triggers: string | string[]): AsyncIterator<T> {
+  public asyncIterator<T>(triggers: string | string[]): AsyncIterableIterator<T> {
     return new PubSubAsyncIterator<T>(this, triggers);
   }
 }

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -4,7 +4,7 @@ export abstract class PubSubEngine {
   public abstract publish(triggerName: string, payload: any): Promise<void>;
   public abstract subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   public abstract unsubscribe(subId: number);
-  public asyncIterator<T>(triggers: string | string[]): PubSubAsyncIterableIterator<T> {
+  public asyncIterableIterator<T>(triggers: string | string[]): PubSubAsyncIterableIterator<T> {
     return new PubSubAsyncIterableIterator<T>(this, triggers);
   }
 }

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -1,10 +1,10 @@
-import {PubSubAsyncIterator} from './pubsub-async-iterator';
+import {PubSubAsyncIterableIterator} from './pubsub-async-iterable-iterator';
 
 export abstract class PubSubEngine {
   public abstract publish(triggerName: string, payload: any): Promise<void>;
   public abstract subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   public abstract unsubscribe(subId: number);
-  public asyncIterator<T>(triggers: string | string[]): AsyncIterableIterator<T> {
-    return new PubSubAsyncIterator<T>(this, triggers);
+  public asyncIterator<T>(triggers: string | string[]): PubSubAsyncIterableIterator<T> {
+    return new PubSubAsyncIterableIterator<T>(this, triggers);
   }
 }

--- a/src/test/asyncIteratorSubscription.ts
+++ b/src/test/asyncIteratorSubscription.ts
@@ -67,7 +67,7 @@ describe('GraphQL-JS asyncIterator', () => {
       }
     `);
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterableIterator(FIRST_EVENT);
     const schema = buildSchema(origIterator);
 
     const results = await subscribe({ schema, document: query }) as AsyncIterableIterator<ExecutionResult>;
@@ -92,7 +92,7 @@ describe('GraphQL-JS asyncIterator', () => {
       }
     `);
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterableIterator(FIRST_EVENT);
     const schema = buildSchema(origIterator, () => Promise.resolve(true));
 
     const results = await subscribe({ schema, document: query }) as AsyncIterableIterator<ExecutionResult>;
@@ -117,7 +117,7 @@ describe('GraphQL-JS asyncIterator', () => {
     `);
 
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterableIterator(FIRST_EVENT);
 
     let counter = 0;
 
@@ -157,7 +157,7 @@ describe('GraphQL-JS asyncIterator', () => {
     `);
 
     const pubsub = new PubSub();
-    const origIterator = pubsub.asyncIterator(FIRST_EVENT);
+    const origIterator = pubsub.asyncIterableIterator(FIRST_EVENT);
     const returnSpy = spy(origIterator, 'return');
     const schema = buildSchema(origIterator);
 

--- a/src/test/asyncIteratorSubscription.ts
+++ b/src/test/asyncIteratorSubscription.ts
@@ -135,7 +135,7 @@ describe('GraphQL-JS asyncIterator', () => {
 
     const schema = buildSchema(origIterator, filterFn);
 
-    Promise.resolve(subscribe({ schema, document: query })).then((results: AsyncIterableIterator<ExecutionResult>) => {
+    Promise.resolve(subscribe({ schema, document: query })).then((results: AsyncIterableIterator<ExecutionResult> | ExecutionResult) => {
       expect(isAsyncIterableIterator(results)).to.be.true;
 
       (results as AsyncGenerator<ExecutionResult, void, void>).next();
@@ -188,19 +188,7 @@ const testFiniteAsyncIterator: AsyncIterableIterator<number> = (async function *
 })();
 
 describe('withFilter', () => {
-
   it('works properly with finite asyncIterators', async () => {
-    const isEven = (x: number) => x % 2 === 0;
-
-    const testFiniteAsyncIterator: AsyncIterator<number> = createAsyncIterator([1, 2, 3, 4, 5, 6, 7, 8]);
-    // Work around https://github.com/leebyron/iterall/issues/48
-    testFiniteAsyncIterator.throw = function (error) {
-      return Promise.reject(error);
-    };
-    testFiniteAsyncIterator.return = function () {
-      return Promise.resolve({ value: undefined, done: true });
-    };
-
     const filteredAsyncIterator = withFilter(() => testFiniteAsyncIterator, isEven)();
 
     for (let i = 1; i <= 4; i++) {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -40,7 +40,7 @@ describe('AsyncIterator', () => {
   it('should expose valid asyncIterator for a specific event', () => {
     const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(eventName);
+    const iterator = ps.asyncIterableIterator(eventName);
     expect(iterator).to.not.be.undefined;
     expect(isAsyncIterableIterator(iterator)).to.be.true;
   });
@@ -48,7 +48,7 @@ describe('AsyncIterator', () => {
   it('should trigger event on asyncIterator when published', done => {
     const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(eventName);
+    const iterator = ps.asyncIterableIterator(eventName);
 
     iterator.next().then(result => {
       expect(result).to.not.be.undefined;
@@ -63,7 +63,7 @@ describe('AsyncIterator', () => {
   it('should not trigger event on asyncIterator when publishing other event', () => {
     const eventName = 'test2';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator('test');
+    const iterator = ps.asyncIterableIterator('test');
     const spy = sinon.spy();
 
     iterator.next().then(spy);
@@ -74,7 +74,7 @@ describe('AsyncIterator', () => {
   it('register to multiple events', done => {
     const eventName = 'test2';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(['test', 'test2']);
+    const iterator = ps.asyncIterableIterator(['test', 'test2']);
     const spy = sinon.spy();
 
     iterator.next().then(() => {
@@ -88,7 +88,7 @@ describe('AsyncIterator', () => {
   it('should not trigger event on asyncIterator already returned', done => {
     const eventName = 'test';
     const ps = new PubSub();
-    const iterator = ps.asyncIterator(eventName);
+    const iterator = ps.asyncIterableIterator(eventName);
 
     iterator.next().then(result => {
       expect(result).to.deep.equal({
@@ -120,7 +120,7 @@ describe('AsyncIterator', () => {
       }
     }
     const ps = new TestPubSub();
-    ps.asyncIterator(testEventName);
+    ps.asyncIterableIterator(testEventName);
 
     expect(ps.listenerCount(testEventName)).to.equal(0);
   });

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -7,7 +7,10 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as sinonChai from 'sinon-chai';
 
 import { PubSub } from '../pubsub';
-import { isAsyncIterable } from 'iterall';
+
+const isAsyncIterableIterator = (input: unknown): input is AsyncIterableIterator<unknown>  => {
+  return input != null && typeof input[Symbol.asyncIterator] === 'function';
+};
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -39,7 +42,7 @@ describe('AsyncIterator', () => {
     const ps = new PubSub();
     const iterator = ps.asyncIterator(eventName);
     expect(iterator).to.not.be.undefined;
-    expect(isAsyncIterable(iterator)).to.be.true;
+    expect(isAsyncIterableIterator(iterator)).to.be.true;
   });
 
   it('should trigger event on asyncIterator when published', done => {

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,10 +1,9 @@
-import { $$asyncIterator } from 'iterall';
 
 export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => boolean | Promise<boolean>;
 export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any>;
 
-interface IterallAsyncIterator<T> extends AsyncIterator<T> {
-  [$$asyncIterator](): IterallAsyncIterator<T>;
+interface IterallAsyncIterator<T> extends AsyncIterableIterator<T> {
+  [Symbol.asyncIterator](): IterallAsyncIterator<T>;
 }
 
 export type WithFilter<TSource = any, TArgs = any, TContext = any> = (
@@ -63,7 +62,7 @@ export function withFilter<TSource = any, TArgs = any, TContext = any>(
       throw(error) {
         return asyncIterator.throw(error);
       },
-      [$$asyncIterator]() {
+      [Symbol.asyncIterator]() {
         return this;
       },
     };


### PR DESCRIPTION
**BREAKING** fixes the type annotation of the abstract class PubSubEngine. According to the TypeScript type-defintion a `PubSubAsyncIterator` instance is actually an `AsyncIterableIterator` instead of an  `AsyncIterator`. The typing of `PubSubAsyncIterator` is way more convenient as it allows iterating over it with the `for await (const foo of iterator) { doSth() }` syntax, which is super handy for filtering or mapping (See https://gist.github.com/n1ru4l/127178705cc0942cad0e45d425e2eb63 for some example operators).

This should be able to get merged once Node.js 10 runs out of LTS. See https://nodejs.org/en/about/releases/
Technically this project already dropped Node.js 10 support when removing the Node.js 10 CI build.

Closes https://github.com/apollographql/graphql-subscriptions/issues/192 Closes https://github.com/apollographql/graphql-subscriptions/issues/192
