### PR TITLE
fix: Support readonly arrays as event names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [@cursorsdottsx](https://github.com/cursorsdottsx) in [#245](https://github.com/apollographql/graphql-subscriptions/pull/245)
 - Replace `iterall` use with native `Symbol.asyncIterator`. <br/>
   [@n1ru4l](https://github.com/n1ru4l) in [#232](https://github.com/apollographql/graphql-subscriptions/pull/232)
+- Support `readonly` arrays of event names. <br/>
+  [@rh389](https://github.com/rh389) in [#234](https://github.com/apollographql/graphql-subscriptions/pull/234)
 
 ### 2.0.1 (not yet released)
 

--- a/src/pubsub-async-iterable-iterator.ts
+++ b/src/pubsub-async-iterable-iterator.ts
@@ -16,7 +16,7 @@ import { PubSubEngine } from './pubsub-engine';
  * A queue of PubSubEngine events waiting for next() calls to be made, which returns the queued events
  * for handling. This queue expands as PubSubEngine events arrive without next() calls occurring in-between.
  *
- * @property eventsArray @type {string[]}
+ * @property eventsArray @type {readonly string[]}
  * An array of PubSubEngine event names that this PubSubAsyncIterator should watch.
  *
  * @property allSubscribed @type {Promise<number[]>}
@@ -36,12 +36,12 @@ export class PubSubAsyncIterableIterator<T> implements AsyncIterableIterator<T> 
 
   private pullQueue: ((value: IteratorResult<T>) => void)[];
   private pushQueue: T[];
-  private eventsArray: string[];
+  private eventsArray: readonly string[];
   private allSubscribed: Promise<number[]>;
   private running: boolean;
   private pubsub: PubSubEngine;
 
-  constructor(pubsub: PubSubEngine, eventNames: string | string[]) {
+  constructor(pubsub: PubSubEngine, eventNames: string | readonly string[]) {
     this.pubsub = pubsub;
     this.pullQueue = [];
     this.pushQueue = [];

--- a/src/pubsub-engine.ts
+++ b/src/pubsub-engine.ts
@@ -4,7 +4,7 @@ export abstract class PubSubEngine {
   public abstract publish(triggerName: string, payload: any): Promise<void>;
   public abstract subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>;
   public abstract unsubscribe(subId: number);
-  public asyncIterableIterator<T>(triggers: string | string[]): PubSubAsyncIterableIterator<T> {
+  public asyncIterableIterator<T>(triggers: string | readonly string[]): PubSubAsyncIterableIterator<T> {
     return new PubSubAsyncIterableIterator<T>(this, triggers);
   }
 }

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -74,7 +74,7 @@ describe('AsyncIterator', () => {
   it('register to multiple events', done => {
     const eventName = 'test2';
     const ps = new PubSub();
-    const iterator = ps.asyncIterableIterator(['test', 'test2']);
+    const iterator = ps.asyncIterator(['test', 'test2'] as const);
     const spy = sinon.spy();
 
     iterator.next().then(() => {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

/label breaking
/label typescript

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

**BREAKING** Allow a `readonly` topics / events array to be passed to `PubSubEngine.asyncIterator()`. I think this is how any well-behaved implementation should treat the incoming array anyway, and it would allow read-only arrays to be accepted upstream (eg https://github.com/MichalLytek/type-graphql/pull/718)

I believe this is (minor) breaking because it could mean downstream subclasses of `PubSubEngine` re-implement `asyncIterator` with incompatible types. It might be best paired with https://github.com/apollographql/graphql-subscriptions/pull/232 ?