### PR TITLE
fix: installing via git not creating dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clean": "rimraf dist coverage",
     "compile": "tsc",
     "pretest": "npm run compile",
-    "prepare": "npm run compile",
     "test": "npm run testonly --",
     "posttest": "npm run lint",
     "lint": "tslint --project ./tsconfig.json ./src/**/*.ts",
@@ -25,7 +24,7 @@
     "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js ./dist/test/asyncIteratorSubscription.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
-    "prepublishOnly": "npm run clean && npm run compile"
+    "prepare": "npm run clean && npm run compile"
   },
   "devDependencies": {
     "@types/chai-as-promised": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clean": "rimraf dist coverage",
     "compile": "tsc",
     "pretest": "npm run compile",
+    "prepare": "npm run compile",
     "test": "npm run testonly --",
     "posttest": "npm run lint",
     "lint": "tslint --project ./tsconfig.json ./src/**/*.ts",


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

When installing via GitHub e.g. `npm i github:apollographql/graphql-subscriptions#master` the dist directory isn't created as the prepare script is missing. This add it.