### PR TITLE
Add a(n optional) generic type map to PubSub.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 3.0.0 (not yet released)
 
-- TODO
+- Add an optional generic type map to `PubSub`. <br/>
+  [@cursorsdottsx](https://github.com/cursorsdottsx) in [#245](https://github.com/apollographql/graphql-subscriptions/pull/245)
 
 ### 2.0.1 (not yet released)
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ To begin with GraphQL subscriptions, start by defining a GraphQL `Subscription` 
 
 ```graphql
 type Subscription {
-    somethingChanged: Result
+  somethingChanged: Result
 }
 
 type Result {
-    id: String
+  id: String
 }
 ```
 
@@ -52,14 +52,14 @@ import { PubSub } from 'graphql-subscriptions';
 export const pubsub = new PubSub();
 ```
 
-However, if you're using TypeScript, then you can use the optional generic parameter for added type-safety:
+If you're using TypeScript you can use the optional generic parameter for added type-safety:
 
 ```ts
 import { PubSub } from "apollo-server-express";
 
 const pubsub = new PubSub<{
-    EVENT_ONE: { data: number; };
-    EVENT_TWO: { data: string; };
+  EVENT_ONE: { data: number; };
+  EVENT_TWO: { data: string; };
 }>();
 
 pubsub.publish("EVENT_ONE", { data: 42 });
@@ -72,7 +72,7 @@ pubsub.subscribe("EVENTONE", () => {});         // ! ERROR
 pubsub.subscribe("EVENT_TWO", () => {});
 ```
 
-Then, implement your Subscriptions type resolver, using the `pubsub.asyncIterator` to map the event you need:
+Next implement your Subscriptions type resolver using the `pubsub.asyncIterator` to map the event you need:
 
 ```js
 const SOMETHING_CHANGED_TOPIC = 'something_changed';
@@ -88,7 +88,7 @@ export const resolvers = {
 
 > Subscriptions resolvers are not a function, but an object with `subscribe` method, that returns `AsyncIterable`.
 
-Finally, the GraphQL engine knows that `somethingChanged` is a subscription, and every time we use `pubsub.publish` over this topic - it will publish it using the transport we use:
+The GraphQL engine now knows that `somethingChanged` is a subscription, and every time we use `pubsub.publish` it will publish content using our chosen transport layer:
 
 ```js
 pubsub.publish(SOMETHING_CHANGED_TOPIC, { somethingChanged: { id: "123" }});

--- a/README.md
+++ b/README.md
@@ -52,7 +52,27 @@ import { PubSub } from 'graphql-subscriptions';
 export const pubsub = new PubSub();
 ```
 
-Now, implement your Subscriptions type resolver, using the `pubsub.asyncIterator` to map the event you need:
+However, if you're using TypeScript, then you can use the optional generic parameter for added type-safety:
+
+```ts
+import { PubSub } from "apollo-server-express";
+
+const pubsub = new PubSub<{
+    EVENT_ONE: { data: number; };
+    EVENT_TWO: { data: string; };
+}>();
+
+pubsub.publish("EVENT_ONE", { data: 42 });
+pubsub.publish("EVENTONE", { data: 42 });       // ! ERROR
+pubsub.publish("EVENT_ONE", { data: "42" });    // ! ERROR
+pubsub.publish("EVENT_TWO", { data: "hello" });
+
+pubsub.subscribe("EVENT_ONE", () => {});
+pubsub.subscribe("EVENTONE", () => {});         // ! ERROR
+pubsub.subscribe("EVENT_TWO", () => {});
+```
+
+Then, implement your Subscriptions type resolver, using the `pubsub.asyncIterator` to map the event you need:
 
 ```js
 const SOMETHING_CHANGED_TOPIC = 'something_changed';
@@ -68,7 +88,7 @@ export const resolvers = {
 
 > Subscriptions resolvers are not a function, but an object with `subscribe` method, that returns `AsyncIterable`.
 
-Now, the GraphQL engine knows that `somethingChanged` is a subscription, and every time we use `pubsub.publish` over this topic - it will publish it using the transport we use:
+Finally, the GraphQL engine knows that `somethingChanged` is a subscription, and every time we use `pubsub.publish` over this topic - it will publish it using the transport we use:
 
 ```js
 pubsub.publish(SOMETHING_CHANGED_TOPIC, { somethingChanged: { id: "123" }});

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -5,7 +5,9 @@ export interface PubSubOptions {
   eventEmitter?: EventEmitter;
 }
 
-export class PubSub extends PubSubEngine {
+export class PubSub<
+  Events extends { [event: string]: unknown } = Record<string, never>
+> extends PubSubEngine {
   protected ee: EventEmitter;
   private subscriptions: { [key: string]: [string, (...args: any[]) => void] };
   private subIdCounter: number;
@@ -17,12 +19,18 @@ export class PubSub extends PubSubEngine {
     this.subIdCounter = 0;
   }
 
-  public publish(triggerName: string, payload: any): Promise<void> {
+  public publish<K extends keyof Events>(
+    triggerName: K & string,
+    payload: Events[K] extends never ? any : Events[K]
+  ): Promise<void> {
     this.ee.emit(triggerName, payload);
     return Promise.resolve();
   }
 
-  public subscribe(triggerName: string, onMessage: (...args: any[]) => void): Promise<number> {
+  public subscribe<K extends keyof Events>(
+    triggerName: K & string,
+    onMessage: (...args: any[]) => void
+  ): Promise<number> {
     this.ee.addListener(triggerName, onMessage);
     this.subIdCounter = this.subIdCounter + 1;
     this.subscriptions[this.subIdCounter] = [triggerName, onMessage];


### PR DESCRIPTION
The class PubSub now has a generic type parameter so its methods `publish` and `subscribe` can be **optionally** type-checked by TypeScript.

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

/label typedefs

I was using [`apollo-server-express`](https://www.npmjs.com/package/apollo-server-express) but the class `PubSub` did not have any compile time validation by TypeScript. So I extended the class and added a generic. I thought I would contribute to the project back since it will be useful to others.

New usage:

```ts
import { PubSub } from "apollo-server-express";

const pubsub = new PubSub<{
    EVENT_ONE: { data: number; };
    EVENT_TWO: { data: string; };
}>();

pubsub.publish("EVENT_ONE", { data: 42 });
pubsub.publish("EVENTONE", { data: 42 }); // ! ERROR
pubsub.publish("EVENT_ONE", { data: "42" }); // ! ERROR
pubsub.publish("EVENT_TWO", { data: "hello" });

pubsub.subscribe("EVENT_ONE", () => {});
pubsub.subscribe("EVENTONE", () => {}); // ! ERROR
pubsub.subscribe("EVENT_TWO", () => {});

const oldPubSub = new PubSub(); // => Still completely fine and should act as if the optional generic was never added.
```