### PR TITLE
docs: add graphql-firebase-subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ It can be easily replaced with some other implementations of [PubSubEngine abstr
 - Use multiple backends with https://github.com/jcoreio/graphql-multiplex-subscriptions
 - Use Ably for multi-protocol support with https://github.com/ably-labs/graphql-ably-pubsub
 - Use Google Firestore with https://github.com/m19c/graphql-firestore-subscriptions
+- Use Google Firebase Realtime Database with https://github.com/swantzter/graphql-firebase-subscriptions
 - Use Amazon's Simple Notification Service (SNS) and Simple Queue Service (SQS) with https://github.com/sagahead-io/graphql-snssqs-subscriptions
 - [Add your implementation...](https://github.com/apollographql/graphql-subscriptions/pull/new/master)
 


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

"companion" PR to https://github.com/apollographql/apollo-server/pull/6059

> I wrote a PubSub implementation that uses Firebase Realtime Database as a message broker, I recently broke it out of the project where it's been in production for a while and polished it up a little, and it should do its job well enough. I'd be happy to have it included in the list of PubSub implementation if you deem it fits