### PR TITLE
Add Payload generic type for pubsub.publish

### DIFF
--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -17,7 +17,7 @@ export class PubSub extends PubSubEngine {
     this.subIdCounter = 0;
   }
 
-  public publish(triggerName: string, payload: any): Promise<void> {
+  public publish<Payload>(triggerName: string, payload: Payload): Promise<void> {
     this.ee.emit(triggerName, payload);
     return Promise.resolve();
   }


### PR DESCRIPTION
Control the payload type when calling `publish.publish()`

**Pull Request Labels**

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

