### PR TITLE
Make WithFilter output type compatible with Apollo Server subscriptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { PubSubEngine } from './pubsub-engine';
 export { PubSub, PubSubOptions } from './pubsub';
-export { withFilter, ResolverFn, FilterFn } from './with-filter';
+export { withFilter, ResolverFn, ResolverIteratorFn, FilterFn } from './with-filter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { PubSubEngine } from './pubsub-engine';
 export { PubSub, PubSubOptions } from './pubsub';
-export { withFilter, ResolverFn, ResolverIteratorFn, FilterFn } from './with-filter';
+export { withFilter, ResolverFn, FilterFn, IterableResolverFn } from './with-filter';

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -15,7 +15,7 @@ const isAsyncIterableIterator = (input: unknown): input is AsyncIterableIterator
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
 const expect = chai.expect;
-const assert = chai.assert;
+const assert: Chai.AssertStatic = chai.assert;
 
 describe('PubSub', function() {
   it('can subscribe and is called when events happen', () => {

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,20 +1,20 @@
 export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => boolean | Promise<boolean>;
-export type ResolverIteratorFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
-export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterableIterator<any> | Promise<AsyncIterableIterator<any>>;
+export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
+export type IterableResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterableIterator<any> | Promise<AsyncIterableIterator<any>>;
 
 interface IterallAsyncIterator<T> extends AsyncIterableIterator<T> {
   [Symbol.asyncIterator](): IterallAsyncIterator<T>;
 }
 
 export type WithFilter<TSource = any, TArgs = any, TContext = any> = (
-  asyncIteratorFn: ResolverIteratorFn<TSource, TArgs, TContext>,
+  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
   filterFn: FilterFn<TSource, TArgs, TContext>
-) => ResolverFn<TSource, TArgs, TContext>;
+) => IterableResolverFn<TSource, TArgs, TContext>;
 
 export function withFilter<TSource = any, TArgs = any, TContext = any>(
-  asyncIteratorFn: ResolverIteratorFn<TSource, TArgs, TContext>,
+  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
   filterFn: FilterFn<TSource, TArgs, TContext>
-): ResolverFn<TSource, TArgs, TContext> {
+): IterableResolverFn<TSource, TArgs, TContext> {
   return async (rootValue: TSource, args: TArgs, context: TContext, info: any): Promise<IterallAsyncIterator<any>> => {
     const asyncIterator = await asyncIteratorFn(rootValue, args, context, info);
 

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,17 +1,18 @@
 export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
+export type ResolverIteratorFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
+export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterableIterator<any> | Promise<AsyncIterableIterator<any>>;
 
 interface IterallAsyncIterator<T> extends AsyncIterableIterator<T> {
   [Symbol.asyncIterator](): IterallAsyncIterator<T>;
 }
 
 export type WithFilter<TSource = any, TArgs = any, TContext = any> = (
-  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
+  asyncIteratorFn: ResolverIteratorFn<TSource, TArgs, TContext>,
   filterFn: FilterFn<TSource, TArgs, TContext>
 ) => ResolverFn<TSource, TArgs, TContext>;
 
 export function withFilter<TSource = any, TArgs = any, TContext = any>(
-  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
+  asyncIteratorFn: ResolverIteratorFn<TSource, TArgs, TContext>,
   filterFn: FilterFn<TSource, TArgs, TContext>
 ): ResolverFn<TSource, TArgs, TContext> {
   return async (rootValue: TSource, args: TArgs, context: TContext, info: any): Promise<IterallAsyncIterator<any>> => {


### PR DESCRIPTION
Subscriptions require an AsyncIterable, but withFilter was returning an AsyncIterator. This updates the type of withFilter to acknowledge it returns a type which is both an AsyncIterable and an AsyncIterator.