### PR TITLE
Bump version and fix repository info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "graphql-subscriptions",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "GraphQL subscriptions for node.js",
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apollostack/graphql-subscriptions.git"
+    "url": "git+https://github.com/apollographql/graphql-subscriptions.git"
   },
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
Bump the package version to 3.0.0 and fix the repository information to use the new project (apollostack -> apollographql).