### PR TITLE
fix: `withFilter` types 

### DIFF
--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,20 +1,20 @@
 export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
+export type ResolverFn<TSource = any, TArgs = any, TContext = any, TResolve = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<TResolve> | Promise<AsyncIterator<TResolve>>;
 export type IterableResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterableIterator<any> | Promise<AsyncIterableIterator<any>>;
 
 interface IterallAsyncIterator<T> extends AsyncIterableIterator<T> {
   [Symbol.asyncIterator](): IterallAsyncIterator<T>;
 }
 
-export type WithFilter<TSource = any, TArgs = any, TContext = any> = (
-  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
-  filterFn: FilterFn<TSource, TArgs, TContext>
+export type WithFilter<TSource = any, TArgs = any, TContext = any, TResolve = any> = (
+  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext, TResolve>,
+  filterFn: FilterFn<TResolve, TArgs, TContext>
 ) => IterableResolverFn<TSource, TArgs, TContext>;
 
-export function withFilter<TSource = any, TArgs = any, TContext = any>(
-  asyncIteratorFn: ResolverFn<TSource, TArgs, TContext>,
-  filterFn: FilterFn<TSource, TArgs, TContext>
-): IterableResolverFn<TSource, TArgs, TContext> {
+  export function withFilter<TSource = any, TArgs = any, TContext = any, TResolve = any>(
+    asyncIteratorFn: ResolverFn<TSource, TArgs, TContext, TResolve>,
+    filterFn: FilterFn<TResolve, TArgs, TContext>
+  ): IterableResolverFn<TSource, TArgs, TContext> {
   return async (rootValue: TSource, args: TArgs, context: TContext, info: any): Promise<IterallAsyncIterator<any>> => {
     const asyncIterator = await asyncIteratorFn(rootValue, args, context, info);
 

--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -1,6 +1,6 @@
-export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => boolean | Promise<boolean>;
-export type ResolverFn<TSource = any, TArgs = any, TContext = any, TResolve = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterator<TResolve> | Promise<AsyncIterator<TResolve>>;
-export type IterableResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue?: TSource, args?: TArgs, context?: TContext, info?: any) => AsyncIterableIterator<any> | Promise<AsyncIterableIterator<any>>;
+export type FilterFn<TSource = any, TArgs = any, TContext = any> = (rootValue: TSource, args: TArgs, context: TContext, info?: any) => boolean | Promise<boolean>;
+export type ResolverFn<TSource = any, TArgs = any, TContext = any, TResolve = any> = (rootValue: TSource, args: TArgs, context: TContext, info?: any) => AsyncIterator<TResolve> | Promise<AsyncIterator<TResolve>>;
+export type IterableResolverFn<TSource = any, TArgs = any, TContext = any> = (rootValue: TSource, args: TArgs, context: TContext, info?: any) => AsyncIterableIterator<any> | Promise<AsyncIterableIterator<any>>;
 
 interface IterallAsyncIterator<T> extends AsyncIterableIterator<T> {
   [Symbol.asyncIterator](): IterallAsyncIterator<T>;


### PR DESCRIPTION
Thank you for the release of the V3. Nonetheless, we encoutered issues while migrating to it with Apollo v4 and graphql-codegen.

Types exposed for `withFilter` function do not match its implementation:
* `TSource` of the filter function is the value returned by the `asyncIterator`
* parameters are optionnal in types but [required line 18.](https://github.com/apollographql/graphql-subscriptions/blob/1a7ee0729192e24b8e6423d55e97402a162ce34e/src/with-filter.ts#L18) Is there a reason for this signature ?